### PR TITLE
Update plugin to handle running alongside kernel build

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,31 @@ The following instructions assume an Ubuntu 22.04 LTS operating system:
   sudo apt install llvm-17 clang-17 libclang-17-dev
   ```
 
+For installation on the FreeBSD operating system, follow these instructions:
+
+- Ninja
+  
+  ```shell
+    sudo pkg install ninja
+  ```
+
+- CMake 3.29.1
+  
+  ```shell
+    sudo pkg install cmake
+  ```
+
+- LLVM 17
+
+  First, check that llvm version 17 is available by running: 
+  ```shell
+    sudo pkg search llvm
+  ```
+
+  If llvm-17 is available:
+  ```shell
+    sudo pkg install llvm17
+  ```
 ### Building the Clang plugin
 
 1. Configure the plugin:
@@ -61,6 +86,14 @@ MacOS:
 ```shell
 /opt/homebrew/opt/llvm@17/bin/clang \
     -fplugin=./build/lib/Debug/libopenbsd_list_macro_printer.dylib \
+    -fsyntax-only \
+    test/slist.c
+```
+
+FreeBSD:
+```shell
+/usr/local/llvm17/bin/clang \
+    -fplugin=./build/lib/Release/libopenbsd_list_macro_printer.dylib \
     -fsyntax-only \
     test/slist.c
 ```

--- a/build-freebsd.sh
+++ b/build-freebsd.sh
@@ -1,0 +1,7 @@
+cmake -S . -B build -G "Ninja Multi-Config" \
+    -D CMAKE_C_COMPILER=/usr/local/llvm17/bin/clang \
+    -D CMAKE_CXX_COMPILER=/usr/local/llvm17/bin/clang++ \
+    -D Clang_DIR=/usr/local/llvm17/lib/cmake/clang \
+    -D LLVM_DIR=/usr/local/llvm17/lib/cmake/llvm
+
+cmake --build build/ --config Release

--- a/lib/ASTConsumer.cc
+++ b/lib/ASTConsumer.cc
@@ -270,7 +270,7 @@ void GenerateColumnCopyFunctionForStruct(clang::ASTContext &Ctx,
 
   // Start generating the function that will copy the struct fields to columns
   file << "static int\n";
-  file << "copy_columns(struct " << DeclName << " *curEntry, dbsc_value **columns, "
+  file << "copy_columns(struct " << DeclName << " *curEntry, struct dbsc_value **columns, "
        << "struct timespec *when, MD5_CTX *context) {\n\n";
 
   // Iterate through the fields of the struct and generate code for assigning values
@@ -355,16 +355,16 @@ void GenerateVtabProcFunctions(clang::ASTContext &Ctx,
   std::string elementTypeName = elementTypeRecord->getNameAsString();
 
   // Write the lock and unlock functions, replacing "proc" with the struct name
-  file << "void\nvtab_" << recordName << "_lock(void)\n{\n"
+  file << "void\nvtab_" << elementTypeName << "_lock(void)\n{\n"
        << "    sx_slock(&" << varName << "_lock);\n"
        << "}\n\n";
 
-  file << "void\nvtab_" << recordName << "_unlock(void)\n{\n"
+  file << "void\nvtab_" << elementTypeName << "_unlock(void)\n{\n"
        << "    sx_sunlock(&" << varName << "_lock);\n"
        << "}\n\n";
 
   // Write the snapshot function, replacing "proc" with the struct name
-  file << "void\nvtab_" << recordName << "_snapshot(sqlite3_vtab *pVtab, struct timespec when)\n"
+  file << "void\nvtab_" << elementTypeName << "_snapshot(sqlite3_vtab *pVtab, struct timespec when)\n"
        << "{\n"
        << "    struct " << elementTypeName << " *prc = LIST_FIRST(&" << varName << ");\n\n"
        << "    osdb_snap *snap = malloc(sizeof(struct osdb_snap), M_SQLITE, M_WAITOK);\n"
@@ -372,7 +372,7 @@ void GenerateVtabProcFunctions(clang::ASTContext &Ctx,
        << "    snap->snap_table = new_osdb_table(VT_" << varName << "_NUM_COLUMNS" << ");\n"
        << "    MD5Init(&snap->context);\n\n"
        << "    while (prc) {\n"
-       << "        dbsc_value **columns = new_osdb_columns(VT_" << varName << "_NUM_COLUMNS" << ");\n"
+       << "        struct dbsc_value **columns = new_osdb_columns(VT_" << varName << "_NUM_COLUMNS" << ");\n"
        << "        if (!columns) {\n"
        << "            return;\n"
        << "        }\n"
@@ -392,17 +392,17 @@ void GenerateVtabProcFunctions(clang::ASTContext &Ctx,
        << "}\n\n";
 
   // Write the Rowid function, replacing "proc" with the struct name
-  file << "static int\nvtab_" << recordName << "_rowid(sqlite3_vtab_cursor *cur, sqlite_int64 *pRowid)\n"
+  file << "static int\nvtab_" << elementTypeName << "_rowid(sqlite3_vtab_cursor *cur, sqlite_int64 *pRowid)\n"
        << "{\n"
        << "    common_cursor *pCur = (common_cursor *)cur;\n"
-       << "    dbsc_value *pid_value = pCur->row->columns[VT_" << varName << "_PID];\n"
+       << "    struct dbsc_value *pid_value = pCur->row->columns[VT_" << varName << "_PID];\n"
        << "    *pRowid = pid_value->int64_value;\n"
        << "    printf(\"" << recordName << "_rowid was called, returning %lld\\n\", *pRowid);\n"
        << "    return SQLITE_OK;\n"
        << "}\n\n";
 
   // Write the BestIndex function, replacing "proc" with the struct name
-  file << "static int\nvtab_" << recordName << "_bestindex(sqlite3_vtab *tab, sqlite3_index_info *pIdxInfo)\n"
+  file << "static int\nvtab_" << elementTypeName << "_bestindex(sqlite3_vtab *tab, sqlite3_index_info *pIdxInfo)\n"
        << "{\n"
        << "    pIdxInfo->estimatedCost = (double)10;\n"
        << "    pIdxInfo->estimatedRows = 10;\n"
@@ -410,11 +410,11 @@ void GenerateVtabProcFunctions(clang::ASTContext &Ctx,
        << "}\n\n";
 
   // Write the Update function, replacing "proc" with the struct name
-  file << "static int\nvtab_" << recordName << "_update(sqlite3_vtab *pVTab, int argc, sqlite3_value **argv, sqlite_int64 *pRowid)\n"
+  file << "static int\nvtab_" << elementTypeName << "_update(sqlite3_vtab *pVTab, int argc, sqlite3_value **argv, sqlite_int64 *pRowid)\n"
        << "{\n"
        << "    struct timespec when;\n"
        << "    nanotime(&when);\n"
-       << "    vtab_" << recordName << "_snapshot(pVTab, when);\n"
+       << "    vtab_" << elementTypeName << "_snapshot(pVTab, when);\n"
        << "    if (osdb_snapshot_compare((struct osdb_vtab *)pVTab) <= 0) {\n"
        << "#ifdef DEBUG\n"
        << "        printf(\"" << recordName << " digest mismatch: UPDATE failed\\n\");\n"

--- a/lib/ASTConsumer.cc
+++ b/lib/ASTConsumer.cc
@@ -444,6 +444,62 @@ void GenerateVtabProcFunctions(clang::ASTContext &Ctx,
   GenerateVtabModule(file, recordName);
 }
 
+void LogStructRelationships(const clang::RecordDecl *RecordDecl) {
+  std::ofstream file("/usr/src/table_src/struct_relationships.txt", std::ios::app);
+
+  if (!file.is_open()) {
+    llvm::errs() << "Error opening struct_relationships.txt\n";
+    return;
+  }
+
+  std::string currentStructName{}; 
+
+  const clang::RecordDecl *matchedStruct = nullptr;
+
+  // Find the first struct type pointed to by any field
+  for (const auto *FieldDecl : RecordDecl->fields()) {
+    const auto *fieldType = FieldDecl->getType().getTypePtr();
+
+    if (fieldType->isPointerType()) {
+      const auto *pointeeType = fieldType->getPointeeType()->getAsRecordDecl();
+      if (pointeeType && pointeeType->isStruct()) {
+        matchedStruct = pointeeType;
+        currentStructName = pointeeType->getNameAsString(); 
+        break; // Exit once the first matching struct is found
+      }
+    }
+  }
+
+  if (!matchedStruct) {
+    file.close();
+    return; // No matching struct found, nothing to log
+  }
+
+  // Iterate through the fields of the matched struct
+  std::vector<std::string> relatedStructs;
+  for (const auto *FieldDecl : matchedStruct->fields()) {
+    const auto *fieldType = FieldDecl->getType().getTypePtr();
+
+    if (fieldType->isPointerType()) {
+      const auto *pointeeType = fieldType->getPointeeType()->getAsRecordDecl();
+      if (pointeeType && pointeeType->isStruct()) {
+        relatedStructs.push_back(pointeeType->getNameAsString());
+      }
+    }
+  }
+
+  // Log the relationships to the file
+  if (!relatedStructs.empty()) {
+    file << currentStructName << ":";
+    for (const auto &relatedStruct : relatedStructs) {
+      file << " " << relatedStruct;
+    }
+    file << "\n";
+  }
+
+  file.close();
+}
+
 /* We only define this constructor because Clang requires it. */
 ASTConsumer::ASTConsumer(clang::CompilerInstance &CI) { (void)CI; }
 
@@ -461,6 +517,7 @@ void ASTConsumer::HandleTranslationUnit(clang::ASTContext &Ctx) {
         continue;
       }
       ProcessedRecords.insert(Match.RecordDecl);
+      LogStructRelationships(Match.RecordDecl);
       /* Print a banner to separate different lists.
        *
        * TODO(Brent): Change the output format to something easily
@@ -479,7 +536,11 @@ void ASTConsumer::HandleTranslationUnit(clang::ASTContext &Ctx) {
         GenerateColumnCopyFunctionForStruct(Ctx, Match, "SLIST_ENTRY", openFile);
       } else if("LIST_HEAD" == Match.OpenBSDListDeclarationMacroName) {
         GenerateColumnCopyFunctionForStruct(Ctx, Match, "LIST_ENTRY", openFile);
-      }
+      } else if("TAILQ_HEAD" == Match.OpenBSDListDeclarationMacroName) {
+        GenerateColumnCopyFunctionForStruct(Ctx, Match, "TAILQ_ENTRY", openFile);
+      } else if("STAILQ_HEAD" == Match.OpenBSDListDeclarationMacroName) {
+        GenerateColumnCopyFunctionForStruct(Ctx, Match, "STAILQ_ENTRY", openFile);
+      } 
       GenerateVtabProcFunctions(Ctx, Match.RecordDecl, Match.VarDecl, openFile);
       openFile.close();
       first = false;

--- a/lib/ASTConsumer.cc
+++ b/lib/ASTConsumer.cc
@@ -425,7 +425,8 @@ void GenerateSerializeForField(clang::ASTContext &Ctx,
                        const clang::VarDecl *varDecl,
                        const clang::FieldDecl *fieldDecl,
                        std::ofstream &file,
-                       const std::string &parentStructName) {
+                       const std::string &parentStructName,
+                       const std::string &parentInstanceVarName) {
   std::string varName;
   if(varDecl) {
     varName = varDecl->getNameAsString();  // Get the allproc variable name
@@ -664,7 +665,7 @@ void GenerateVtabProcFunctionsForField(clang::ASTContext &Ctx,
                                        const clang::FieldDecl *fieldDecl,
                                        std::ofstream &file,
                                        const std::string &parentStructName,
-                                       const std::String &parentInstanceVarName) {
+                                       const std::string &parentInstanceVarName) {
   std::string varName = fieldDecl->getNameAsString();  // Get the allproc variable name
   const clang::FieldDecl *firstField = *recordDecl->field_begin();
   const clang::RecordDecl *elementTypeRecord =
@@ -924,7 +925,7 @@ void ASTConsumer::HandleTranslationUnit(clang::ASTContext &Ctx) {
 
         llvm::outs() << "PROCESSING FIELD DECL" << '\n'; 
         
-        GenerateVtabProcFunctionsForField(Ctx, Match.RecordDecl, Match.FieldDecl, openFile, parentStructNam, parentInstanceVarName);
+        GenerateVtabProcFunctionsForField(Ctx, Match.RecordDecl, Match.FieldDecl, openFile, parentStructName, parentInstanceVarName);
         GenerateSerializeForField(Ctx, Match.RecordDecl, Match.VarDecl, Match.FieldDecl, openFile, parentStructName, parentInstanceVarName);
       } else {
         GenerateVtabProcFunctions(Ctx, Match.RecordDecl, Match.VarDecl, openFile);

--- a/lib/ASTConsumer.cc
+++ b/lib/ASTConsumer.cc
@@ -886,29 +886,44 @@ void ASTConsumer::HandleTranslationUnit(clang::ASTContext &Ctx) {
 
         // Step 2: Iterate through top-level VarDecls to find one whose type matches the parent struct
         std::string parentInstanceVarName;
+        const clang::RecordDecl *parentStructDecl = nullptr;
+
+        // First, find the actual RecordDecl for the parentStructName
         for (auto decl : Ctx.getTranslationUnitDecl()->decls()) {
-          if (const auto *varDecl = llvm::dyn_cast<clang::VarDecl>(decl)) {
-            const clang::QualType type = varDecl->getType();
-            const clang::Type *typePtr = type.getTypePtrOrNull();
-            if (!typePtr) continue;
+          if (const auto *record = llvm::dyn_cast<clang::RecordDecl>(decl)) {
+            if (record->getNameAsString() == parentStructName) {
+              parentStructDecl = record;
+              break;
+            }
+          }
+        }
 
-            if (const auto *recordType = typePtr->getAsStructureType()) {
-              const auto *record = recordType->getDecl();
-              for (const auto *field : record->fields()) {
-                const clang::Type *fieldType = field->getType().getTypePtrOrNull();
-                if (!fieldType || !fieldType->isPointerType()) continue;
+        if (!parentStructDecl) {
+          llvm::errs() << "Could not find RecordDecl for " << parentStructName << "\n";
+        } else {
+          for (auto decl : Ctx.getTranslationUnitDecl()->decls()) {
+            if (const auto *varDecl = llvm::dyn_cast<clang::VarDecl>(decl)) {
+              const clang::QualType type = varDecl->getType();
+              const clang::Type *typePtr = type.getTypePtrOrNull();
+              if (!typePtr) continue;
 
-                const clang::Type *pointee = fieldType->getPointeeType().getTypePtrOrNull();
-                const auto *pointeeRecord = pointee ? pointee->getAsRecordDecl() : nullptr;
+              if (const auto *recordType = typePtr->getAsStructureType()) {
+                const auto *record = recordType->getDecl();
+                for (const auto *field : record->fields()) {
+                  const clang::Type *fieldType = field->getType().getTypePtrOrNull();
+                  if (!fieldType || !fieldType->isPointerType()) continue;
 
-                if (pointeeRecord && pointeeRecord->getNameAsString() == parentStructName) {
-                  parentInstanceVarName = varDecl->getNameAsString(); // e.g., "allproc"
-                  goto found; // break out of nested loop
+                  const auto *pointee = fieldType->getPointeeType()->getAsRecordDecl();
+                  if (pointee && pointee->getCanonicalDecl() == parentStructDecl->getCanonicalDecl()) {
+                    parentInstanceVarName = varDecl->getNameAsString();
+                    goto found;
+                  }
                 }
               }
             }
           }
         }
+
         found:;
 
         llvm::outs() << "PROCESSING FIELD DECL" << '\n'; 

--- a/lib/ASTConsumer.cc
+++ b/lib/ASTConsumer.cc
@@ -236,7 +236,7 @@ void GenerateIncludePaths(const clang::RecordDecl *recordDecl, std::ofstream& fi
        << "#include <sys/signal.h>\n"
        << "#include <sys/tty.h>\n"
        << "\n"
-       << "#include <dbsc/value.h>"
+       << "#include <dbsc/value.h>\n"
        << "\n"
        << "#include \"osdb.h\"\n"
        << "#include \"osdb_mod.h\"\n"
@@ -338,7 +338,7 @@ void GenerateSerialize(clang::ASTContext &Ctx,
   file << "        \"CREATE TABLE " << tableName << " (";
 
   bool first = true;
-  std::vector<std::string> handledFields;
+  int colCount = 0;
   for (const auto *field : elementTypeRecord->fields()) {
     auto fieldType = field->getType().getTypePtr();
     if (!(fieldType->isEnumeralType() || fieldType->isIntegerType() ||
@@ -349,7 +349,7 @@ void GenerateSerialize(clang::ASTContext &Ctx,
     first = false;
 
     std::string fieldName = field->getNameAsString();
-    handledFields.push_back(fieldName);
+    colCount++;
 
     file << fieldName << " ";
     if (fieldType->isEnumeralType() || fieldType->isIntegerType()) {
@@ -364,7 +364,7 @@ void GenerateSerialize(clang::ASTContext &Ctx,
 
   // === Insert Statement ===
   file << "    const char *insert_stmt = \"INSERT INTO " << tableName << " VALUES (";
-  for (size_t i = 0; i < handledFields.size(); ++i) {
+  for (size_t i = 0; i < colCount; ++i) {
     if (i > 0) file << ", ";
     file << "?";
   }
@@ -374,26 +374,22 @@ void GenerateSerialize(clang::ASTContext &Ctx,
 
   // === While loop over linked list ===
   file << "    while (entry) {\n";
-  file << "        dbsc_value **columns = new_osdb_columns(VT_" << varName << "_NUM_COLUMNS);\n";
-
   file << "        int bindIndex = 1;\n";
-  for (const auto &fieldName : handledFields) {
-    file << "        {\n";
-    file << "            dbsc_value *val = columns[VT" << varName << "_" << fieldName << "];\n";
-    file << "            switch (val->type) {\n";
-    file << "                case DBSC_INT64:\n";
-    file << "                    sqlite3_bind_int64(stmt, bindIndex++, val->int64_value);\n";
-    file << "                    break;\n";
-    file << "                case DBSC_TEXT:\n";
-    file << "                    sqlite3_bind_text(stmt, bindIndex++, val->text_value, -1, SQLITE_STATIC);\n";
-    file << "                    break;\n";
-    file << "                default:\n";
-    file << "                    sqlite3_bind_null(stmt, bindIndex++);\n";
-    file << "                    break;\n";
-    file << "            }\n";
-    file << "        }\n";
+  for (const auto *field : elementTypeRecord->fields()) {
+    auto fieldType = field->getType().getTypePtr();
+    if (!(fieldType->isEnumeralType() || fieldType->isIntegerType() ||
+          (fieldType->isPointerType() && fieldType->getPointeeType()->isCharType())))
+      continue;
+
+    std::string fieldName = field->getNameAsString();
+    if (fieldType->isEnumeralType() || fieldType->isIntegerType()) {
+      file << "           sqlite3_bind_int64(stmt, bindIndex++, entry->" << fieldName << ");\n";
+    } else {
+      file << "           sqlite3_bind_text(stmt, bindIndex++, entry->" << fieldName << ");\n";
+    }
   }
 
+  file << "\n";
   file << "        sqlite3_step(stmt);\n";
   file << "        sqlite3_reset(stmt);\n";
   file << "        entry = LIST_NEXT(entry,  p_list);\n";
@@ -509,6 +505,9 @@ void GenerateVtabProcFunctions(clang::ASTContext &Ctx,
        << "    pIdxInfo->estimatedRows = 10;\n"
        << "    return SQLITE_OK;\n"
        << "}\n\n";
+  
+  file << "extern int kern_cpuset_setaffinity(struct thread *td, cpulevel_t level, cpuwhich_t which, id_t id, cpuset_t *mask);\n"
+  file << "extern int cpuset_setproc(pid_t pid, struct cpuset *set, cpuset_t *mask, struct domainset *domain, bool rebase);\n"
 
   // Write the Update function, replacing "proc" with the struct name
   file << "static int\n" << elementTypeName << "vtabUpdate(sqlite3_vtab *pVTab, int argc, sqlite3_value **argv, sqlite_int64 *pRowid)\n"
@@ -657,3 +656,4 @@ void ASTConsumer::HandleTranslationUnit(clang::ASTContext &Ctx) {
   }
 }
 } // namespace openbsd_list_macro_printer
+

--- a/lib/ASTConsumer.cc
+++ b/lib/ASTConsumer.cc
@@ -307,9 +307,14 @@ void GenerateColumnCopyFunctionForStruct(clang::ASTContext &Ctx,
       // Assuming string field is a char pointer
       file << "new_dbsc_text(curEntry->" << field->getNameAsString() << ", "
            << "strlen(curEntry->" << field->getNameAsString() << ") + 1, context);\n";
+    } else if (fieldType->isPointerType()) {
+      // For all other pointer types, store as int64
+      file << "    columns[VT_" << DeclName << "_" << field->getNameAsString() << "] = ";
+      file << "new_dbsc_int64((int64_t)(uintptr_t)curEntry->"
+          << field->getNameAsString() << ", context);\n";
     } else {
       file << "//    columns[VT_" << DeclName << "_" << field->getNameAsString() << "] = ";
-      file << " TODO: Handle other types\n";
+      file << " /* Unsupported type */\n";
     }
   }
 
@@ -364,7 +369,7 @@ void GenerateSerialize(clang::ASTContext &Ctx,
 
   // === Insert Statement ===
   file << "    const char *insert_stmt = \"INSERT INTO " << tableName << " VALUES (";
-  for (size_t i = 0; i < colCount; ++i) {
+  for (int i = 0; i < colCount; ++i) {
     if (i > 0) file << ", ";
     file << "?";
   }

--- a/lib/ASTConsumer.cc
+++ b/lib/ASTConsumer.cc
@@ -441,7 +441,7 @@ void GenerateSerializeForField(clang::ASTContext &Ctx,
   const std::string tableName = std::string("all_") + elementTypeName + "s";
 
   file << "void vtab_" << elementTypeName << "_serialize(sqlite3 *real_db, struct timespec when) {\n";
-  file << "    struct " << elementTypeName << " *entry = LIST_FIRST(&" << varName << ");\n\n";
+  file << "    struct " << parentStructName << " *entry = LIST_FIRST(&" << parentInstanceVarName << ");\n\n";
 
   // === Create Table ===
   file << "    const char *create_stmt =\n";
@@ -484,7 +484,9 @@ void GenerateSerializeForField(clang::ASTContext &Ctx,
 
   // === While loop over linked list ===
   file << "    while (entry) {\n";
-  file << "        int bindIndex = 1;\n";
+  file << "        struct " << elementTypeName << " *entry2 = TAILQ_FIRST(&entry->"<< varName <<");\n"
+  file << "        while (entry2) {\n"
+  file << "             int bindIndex = 1;\n";
   for (const auto *field : elementTypeRecord->fields()) {
     auto fieldType = field->getType().getTypePtr();
     if (!(fieldType->isEnumeralType() || fieldType->isIntegerType() ||
@@ -493,15 +495,16 @@ void GenerateSerializeForField(clang::ASTContext &Ctx,
 
     std::string fieldName = field->getNameAsString();
     if (fieldType->isEnumeralType() || fieldType->isIntegerType() || (fieldType->isPointerType() && !fieldType->getPointeeType()->isCharType())) {
-      file << "           sqlite3_bind_int64(stmt, bindIndex++, entry->" << fieldName << ");\n";
+      file << "             sqlite3_bind_int64(stmt, bindIndex++, entry2->" << fieldName << ");\n";
     } else {
-      file << "           sqlite3_bind_text(stmt, bindIndex++, entry->" << fieldName << ", -1, SQLITE_TRANSIENT);\n";
+      file << "             sqlite3_bind_text(stmt, bindIndex++, entry2->" << fieldName << ", -1, SQLITE_TRANSIENT);\n";
     }
   }
-
+  file << "             sqlite3_step(stmt);\n";
+  file << "             sqlite3_reset(stmt);\n";
+  file << "             entry2 = TAILQ_NEXT(entry2, td_plist);\n"
+  file << "        }\n"
   file << "\n";
-  file << "        sqlite3_step(stmt);\n";
-  file << "        sqlite3_reset(stmt);\n";
   file << "        entry = LIST_NEXT(entry,  p_list);\n";
   file << "    }\n\n";
 
@@ -691,15 +694,15 @@ void GenerateVtabProcFunctionsForField(clang::ASTContext &Ctx,
        << "    MD5Init(&snap->context);\n\n"
        << "    while (entry) {\n"
        << "        struct " << elementTypeName << " *entry2 = TAILQ_FIRST(&entry->"<< varName <<");\n"
-       << "             while (entry2) {\n"
-       << "                  struct dbsc_value **columns = new_osdb_columns(VT_" << varName << "_NUM_COLUMNS" << ");\n"
-       << "                  if (!columns) {\n"
-       << "                       return;\n"
-       << "                  }\n"
-       << "                  copy_columns(entry2, columns, &snap->when, &snap->context);\n"
-       << "                  osdb_table_push(snap->snap_table, columns);\n"
-       << "                  entry2 = TAILQ_NEXT(entry2, td_plist);\n"
-       << "             }\n"
+       << "        while (entry2) {\n"
+       << "              struct dbsc_value **columns = new_osdb_columns(VT_" << varName << "_NUM_COLUMNS" << ");\n"
+       << "              if (!columns) {\n"
+       << "                    return;\n"
+       << "              }\n"
+       << "              copy_columns(entry2, columns, &snap->when, &snap->context);\n"
+       << "              osdb_table_push(snap->snap_table, columns);\n"
+       << "              entry2 = TAILQ_NEXT(entry2, td_plist);\n"
+       << "         }\n"
        << "        entry = LIST_NEXT(entry, p_list);\n"
        << "    }\n\n"
        << "    MD5Final(snap->digest, &snap->context);\n"
@@ -885,7 +888,6 @@ void ASTConsumer::HandleTranslationUnit(clang::ASTContext &Ctx) {
         }
 
         // Step 2: Iterate through top-level VarDecls to find one whose type matches the parent struct
-
         std::string parentInstanceVarName;
         for (auto decl : Ctx.getTranslationUnitDecl()->decls()) {
           if (const auto *varDecl = llvm::dyn_cast<clang::VarDecl>(decl)) {

--- a/lib/ASTConsumer.cc
+++ b/lib/ASTConsumer.cc
@@ -297,7 +297,7 @@ void GenerateColumnCopyFunctionForStruct(clang::ASTContext &Ctx,
     auto fieldType = field->getType().getTypePtr(); 
     if (fieldType->isEnumeralType()) {
       file << "    columns[VT_" << DeclName << "_" << field->getNameAsString() << "] = ";
-      file << "new_dbsc_int64(static_cast<int64_t>(curEntry->" 
+      file << "new_dbsc_int64((int64_t)(curEntry->" 
              << field->getNameAsString() << "), context); // TODO: need better enum representation \n";
     } else if (fieldType->isIntegerType()) {
       file << "    columns[VT_" << DeclName << "_" << field->getNameAsString() << "] = ";
@@ -385,7 +385,7 @@ void GenerateSerialize(clang::ASTContext &Ctx,
     if (fieldType->isEnumeralType() || fieldType->isIntegerType()) {
       file << "           sqlite3_bind_int64(stmt, bindIndex++, entry->" << fieldName << ");\n";
     } else {
-      file << "           sqlite3_bind_text(stmt, bindIndex++, entry->" << fieldName << ");\n";
+      file << "           sqlite3_bind_text(stmt, bindIndex++, entry->" << fieldName << ", -1, SQLITE_TRANSIENT);\n";
     }
   }
 
@@ -507,7 +507,7 @@ void GenerateVtabProcFunctions(clang::ASTContext &Ctx,
        << "}\n\n";
   
   file << "extern int kern_cpuset_setaffinity(struct thread *td, cpulevel_t level, cpuwhich_t which, id_t id, cpuset_t *mask);\n"
-  file << "extern int cpuset_setproc(pid_t pid, struct cpuset *set, cpuset_t *mask, struct domainset *domain, bool rebase);\n"
+  file << "extern int cpuset_setproc(pid_t pid, struct cpuset *set, cpuset_t *mask, struct domainset *domain, bool rebase);\n\n"
 
   // Write the Update function, replacing "proc" with the struct name
   file << "static int\n" << elementTypeName << "vtabUpdate(sqlite3_vtab *pVTab, int argc, sqlite3_value **argv, sqlite_int64 *pRowid)\n"

--- a/lib/ASTConsumer.cc
+++ b/lib/ASTConsumer.cc
@@ -227,12 +227,7 @@ std::ofstream OpenFile(OpenBSDQueueMacroDecl LIST_HEADDecl) {
 //   return file; 
 // }
 
-void GenerateIncludePaths(const clang::RecordDecl *recordDecl, std::ofstream& file) {
-  const clang::FieldDecl *firstField = *recordDecl->field_begin();
-  const clang::RecordDecl *elementTypeRecord =
-      firstField->getType()->getPointeeType()->getAsRecordDecl();
-  std::string elementTypeName = elementTypeRecord->getNameAsString(); // proc
-
+void GenerateIncludePaths(const std::string &elementTypeName, std::ofstream& file) {
   file << "#include <sys/types.h>\n"
        << "#include <sys/systm.h>\n"
        << "#include <sys/libkern.h>\n"
@@ -553,7 +548,7 @@ void GenerateVtabModule(std::ofstream& file, const std::string& recordName) {
          << "        vtable_type_to_name(((osdb_vtab *)pAux)->type), &" << recordName
          << "vtabModule,\n"
          << "        pAux);\n"
-         << "}\n";
+         << "}\n\n";
 }
 
 void GenerateVtabProcFunctions(clang::ASTContext &Ctx,
@@ -677,11 +672,11 @@ void GenerateVtabProcFunctionsForField(clang::ASTContext &Ctx,
 
   // Write the lock and unlock functions, replacing "proc" with the struct name
   file << "void\nvtab_" << elementTypeName << "_lock(void)\n{\n"
-       << "    sx_slock(&" << varName << "_lock);\n"
+       << "    sx_slock(&" << parentInstanceVarName << "_lock);\n"
        << "}\n\n";
 
   file << "void\nvtab_" << elementTypeName << "_unlock(void)\n{\n"
-       << "    sx_sunlock(&" << varName << "_lock);\n"
+       << "    sx_sunlock(&" << parentInstanceVarName << "_lock);\n"
        << "}\n\n";
 
   // Write the snapshot function, replacing "proc" with the struct name
@@ -718,10 +713,6 @@ void GenerateVtabProcFunctionsForField(clang::ASTContext &Ctx,
 
   file << "static int\n" << elementTypeName << "vtabRowid(sqlite3_vtab_cursor *cur, sqlite_int64 *pRowid)\n"
        << "{\n"
-       << "    common_cursor *pCur = (common_cursor *)cur;\n"
-       << "    struct dbsc_value *pid_value = pCur->row->columns[VT_" << varName << "_p_pid];\n"
-       << "    *pRowid = pid_value->int64_value;\n"
-       << "    printf(\"" << elementTypeName << "_rowid was called, returning %lld\\n\", *pRowid);\n"
        << "    return SQLITE_OK;\n"
        << "}\n\n";
 
@@ -862,23 +853,12 @@ void ASTConsumer::HandleTranslationUnit(clang::ASTContext &Ctx) {
       if (!openFile.is_open()) {
         continue;
       }
-      GenerateIncludePaths(Match.RecordDecl, openFile);
-      if ("SLIST_HEAD" == Match.OpenBSDListDeclarationMacroName) {
-        GenerateColumnCopyFunctionForStruct(Ctx, Match, "SLIST_ENTRY", openFile);
-      } else if ("LIST_HEAD" == Match.OpenBSDListDeclarationMacroName) {
-        GenerateColumnCopyFunctionForStruct(Ctx, Match, "LIST_ENTRY", openFile);
-      } else if ("TAILQ_HEAD" == Match.OpenBSDListDeclarationMacroName) {
-        llvm::outs() << "TAILQ HEAD DECLARATION" << '\n';
-        GenerateColumnCopyFunctionForStruct(Ctx, Match, "TAILQ_ENTRY", openFile);
-      } else if ("STAILQ_HEAD" == Match.OpenBSDListDeclarationMacroName) {
-        llvm::outs() << "STAILQ HEAD DECLARATION" << '\n';
-        GenerateColumnCopyFunctionForStruct(Ctx, Match, "STAILQ_ENTRY", openFile);
-      }
-      
-      // Call the appropriate vtab function based on whether we matched a varDecl or a fieldDecl.
+      std::string parentStructName;
+      std::string parentInstanceVarName;
+      std::string elementTypeName = Match.RecordDecl->field_begin()->getType()->getPointeeType()->getAsRecordDecl()->getNameAsString();
+
       if (Match.FieldDecl) {
         // Retrieve the name of the parent struct that contains this field.
-        std::string parentStructName;
         auto parents = Ctx.getParents(*Match.FieldDecl);
         for (const auto &parent : parents) {
           if (const auto *record = parent.get<clang::RecordDecl>()) {
@@ -887,8 +867,7 @@ void ASTConsumer::HandleTranslationUnit(clang::ASTContext &Ctx) {
           }
         }
 
-        // Step 2: Iterate through top-level VarDecls to find one whose type matches the parent struct
-        std::string parentInstanceVarName;
+        // Iterate through top-level VarDecls to find one whose type matches the parent struct
         for (auto decl : Ctx.getTranslationUnitDecl()->decls()) {
           if (const auto *varDecl = llvm::dyn_cast<clang::VarDecl>(decl)) {
             const clang::QualType type = varDecl->getType();
@@ -919,9 +898,24 @@ void ASTConsumer::HandleTranslationUnit(clang::ASTContext &Ctx) {
         }
         found:
         ;
+      }
 
+      GenerateIncludePaths(parentStructName.empty() ? elementTypeName, openFile);
+      if ("SLIST_HEAD" == Match.OpenBSDListDeclarationMacroName) {
+        GenerateColumnCopyFunctionForStruct(Ctx, Match, "SLIST_ENTRY", openFile);
+      } else if ("LIST_HEAD" == Match.OpenBSDListDeclarationMacroName) {
+        GenerateColumnCopyFunctionForStruct(Ctx, Match, "LIST_ENTRY", openFile);
+      } else if ("TAILQ_HEAD" == Match.OpenBSDListDeclarationMacroName) {
+        llvm::outs() << "TAILQ HEAD DECLARATION" << '\n';
+        GenerateColumnCopyFunctionForStruct(Ctx, Match, "TAILQ_ENTRY", openFile);
+      } else if ("STAILQ_HEAD" == Match.OpenBSDListDeclarationMacroName) {
+        llvm::outs() << "STAILQ HEAD DECLARATION" << '\n';
+        GenerateColumnCopyFunctionForStruct(Ctx, Match, "STAILQ_ENTRY", openFile);
+      }
+      
+      // Call the appropriate vtab function based on whether we matched a varDecl or a fieldDecl.
+      if (Match.FieldDecl) {
         llvm::outs() << "PROCESSING FIELD DECL" << '\n'; 
-        
         GenerateVtabProcFunctionsForField(Ctx, Match.RecordDecl, Match.FieldDecl, openFile, parentStructName, parentInstanceVarName);
         GenerateSerializeForField(Ctx, Match.RecordDecl, Match.VarDecl, Match.FieldDecl, openFile, parentStructName, parentInstanceVarName);
       } else {

--- a/lib/ASTConsumer.cc
+++ b/lib/ASTConsumer.cc
@@ -420,6 +420,95 @@ void GenerateSerialize(clang::ASTContext &Ctx,
   file << "}\n\n";
 }
 
+void GenerateSerializeForField(clang::ASTContext &Ctx,
+                       const clang::RecordDecl *recordDecl,
+                       const clang::VarDecl *varDecl,
+                       const clang::FieldDecl *fieldDecl,
+                       std::ofstream &file,
+                       const std::string &parentStructName) {
+  std::string varName;
+  if(varDecl) {
+    varName = varDecl->getNameAsString();  // Get the allproc variable name
+  } else {
+    varName = fieldDecl->getNameAsString();  // Get the allproc variable name
+  }
+  const clang::FieldDecl *firstField = *recordDecl->field_begin();
+  const clang::RecordDecl *elementTypeRecord =
+      firstField->getType()->getPointeeType()->getAsRecordDecl();
+  std::string elementTypeName = elementTypeRecord->getNameAsString(); // proc
+
+  const std::string tableName = std::string("all_") + elementTypeName + "s";
+
+  file << "void vtab_" << elementTypeName << "_serialize(sqlite3 *real_db, struct timespec when) {\n";
+  file << "    struct " << elementTypeName << " *entry = LIST_FIRST(&" << varName << ");\n\n";
+
+  // === Create Table ===
+  file << "    const char *create_stmt =\n";
+  file << "        \"CREATE TABLE " << tableName << " (";
+
+  bool first = true;
+  int colCount = 0;
+  for (const auto *field : elementTypeRecord->fields()) {
+    auto fieldType = field->getType().getTypePtr();
+    if (!(fieldType->isEnumeralType() || fieldType->isIntegerType() || fieldType->isPointerType()))
+      continue;
+
+    if (!first) file << ", ";
+    first = false;
+
+    std::string fieldName = field->getNameAsString();
+    colCount++;
+
+    file << fieldName << " ";
+    if (fieldType->isEnumeralType() || fieldType->isIntegerType() || (fieldType->isPointerType() && !fieldType->getPointeeType()->isCharType())) {
+      file << "INTEGER";
+    }
+    else {
+      file << "TEXT";
+    }
+  }
+  file << ")\";\n";
+  file << "    char *errMsg = NULL;\n";
+  file << "    sqlite3_exec(real_db, create_stmt, NULL, NULL, &errMsg);\n\n";
+
+  // === Insert Statement ===
+  file << "    const char *insert_stmt = \"INSERT INTO " << tableName << " VALUES (";
+  for (int i = 0; i < colCount; ++i) {
+    if (i > 0) file << ", ";
+    file << "?";
+  }
+  file << ")\";\n";
+  file << "    sqlite3_stmt *stmt = NULL;\n";
+  file << "    sqlite3_prepare_v2(real_db, insert_stmt, -1, &stmt, NULL);\n\n";
+
+  // === While loop over linked list ===
+  file << "    while (entry) {\n";
+  file << "        int bindIndex = 1;\n";
+  for (const auto *field : elementTypeRecord->fields()) {
+    auto fieldType = field->getType().getTypePtr();
+    if (!(fieldType->isEnumeralType() || fieldType->isIntegerType() ||
+          (fieldType->isPointerType() && fieldType->getPointeeType()->isCharType())))
+      continue;
+
+    std::string fieldName = field->getNameAsString();
+    if (fieldType->isEnumeralType() || fieldType->isIntegerType() || (fieldType->isPointerType() && !fieldType->getPointeeType()->isCharType())) {
+      file << "           sqlite3_bind_int64(stmt, bindIndex++, entry->" << fieldName << ");\n";
+    } else {
+      file << "           sqlite3_bind_text(stmt, bindIndex++, entry->" << fieldName << ", -1, SQLITE_TRANSIENT);\n";
+    }
+  }
+
+  file << "\n";
+  file << "        sqlite3_step(stmt);\n";
+  file << "        sqlite3_reset(stmt);\n";
+  file << "        entry = LIST_NEXT(entry,  p_list);\n";
+  file << "    }\n\n";
+
+  file << "    sqlite3_finalize(stmt);\n";
+  file << "}\n\n";
+}
+
+
 void GenerateVtabModule(std::ofstream& file, const std::string& recordName) {
     file << "/*\n** This following structure defines all the methods for the\n"
          << "** virtual table.\n*/\n";
@@ -574,7 +663,8 @@ void GenerateVtabProcFunctionsForField(clang::ASTContext &Ctx,
                                        const clang::RecordDecl *recordDecl,
                                        const clang::FieldDecl *fieldDecl,
                                        std::ofstream &file,
-                                       const std::string &parentStructName) {
+                                       const std::string &parentStructName,
+                                       const std::String &parentInstanceVarName) {
   std::string varName = fieldDecl->getNameAsString();  // Get the allproc variable name
   const clang::FieldDecl *firstField = *recordDecl->field_begin();
   const clang::RecordDecl *elementTypeRecord =
@@ -593,19 +683,23 @@ void GenerateVtabProcFunctionsForField(clang::ASTContext &Ctx,
   // Write the snapshot function, replacing "proc" with the struct name
   file << "void\nvtab_" << elementTypeName << "_snapshot(sqlite3_vtab *pVtab, struct timespec when)\n"
        << "{\n"
-       << "    struct " << elementTypeName << " *prc = LIST_FIRST(&" << varName << ");\n\n"
+       << "    struct " << parentStructName << " *entry = LIST_FIRST(&" << parentInstanceVarName << ");\n\n"
        << "    osdb_snap *snap = malloc(sizeof(struct osdb_snap), M_SQLITE, M_WAITOK);\n"
        << "    snap->when = when;\n"
        << "    snap->snap_table = new_osdb_table(VT_" << varName << "_NUM_COLUMNS" << ");\n"
        << "    MD5Init(&snap->context);\n\n"
-       << "    while (prc) {\n"
-       << "        struct dbsc_value **columns = new_osdb_columns(VT_" << varName << "_NUM_COLUMNS" << ");\n"
-       << "        if (!columns) {\n"
-       << "            return;\n"
-       << "        }\n"
-       << "        copy_columns(prc, columns, &snap->when, &snap->context);\n"
-       << "        osdb_table_push(snap->snap_table, columns);\n"
-       << "        prc = LIST_NEXT(prc, p_list);\n"
+       << "    while (entry) {\n"
+       << "        struct " << elementTypeName << " *entry2 = TAILQ_FIRST(&entry->"<< varName <<");\n"
+       << "             while (entry2) {\n"
+       << "                  struct dbsc_value **columns = new_osdb_columns(VT_" << varName << "_NUM_COLUMNS" << ");\n"
+       << "                  if (!columns) {\n"
+       << "                       return;\n"
+       << "                  }\n"
+       << "                  copy_columns(entry2, columns, &snap->when, &snap->context);\n"
+       << "                  osdb_table_push(snap->snap_table, columns);\n"
+       << "                  entry2 = TAILQ_NEXT(entry2, td_plist);\n"
+       << "             }\n"
+       << "        entry = LIST_NEXT(entry, p_list);\n"
        << "    }\n\n"
        << "    MD5Final(snap->digest, &snap->context);\n"
        << "#ifdef DEBUG\n"
@@ -781,22 +875,62 @@ void ASTConsumer::HandleTranslationUnit(clang::ASTContext &Ctx) {
       if (Match.FieldDecl) {
         // Retrieve the name of the parent struct that contains this field.
         std::string parentStructName;
-        // auto parents = Ctx.getParents(*Match.FieldDecl);
-        // for (const auto &parent : parents) {
-        //   if (const auto *record = parent.get<clang::RecordDecl>()) {
-        //     parentStructName = record->getNameAsString();
-        //     break;
-        //   }
-        // }
+        auto parents = Ctx.getParents(*Match.FieldDecl);
+        for (const auto &parent : parents) {
+          if (const auto *record = parent.get<clang::RecordDecl>()) {
+            parentStructName = record->getNameAsString();
+            break;
+          }
+        }
+
+        // Step 2: Iterate through top-level VarDecls to find one whose type matches the parent struct
+        std::string parentInstanceVarName;
+        for (auto decl : Ctx.getTranslationUnitDecl()->decls()) {
+          if (const auto *varDecl = llvm::dyn_cast<clang::VarDecl>(decl)) {
+            const clang::QualType type = varDecl->getType();
+
+            // Direct struct match
+            if (const auto *record = type->getAsRecordDecl()) {
+              if (record->getNameAsString() == parentStructName) {
+                parentInstanceVarName = varDecl->getNameAsString(); // e.g., "allproc"
+                break;
+              }
+            }
+
+            // Pointer to struct
+            if (type->isPointerType()) {
+              const auto *pointee = type->getPointeeType().getTypePtrOrNull();
+              if (pointee) {
+                if (const auto *record = pointee->getAsRecordDecl()) {
+                  if (record->getNameAsString() == parentStructName) {
+                    parentInstanceVarName = varDecl->getNameAsString();
+                    break;
+                  }
+                }
+              }
+            }
+
+            // Handle typedefs or queue types (conservatively)
+            if (const auto *desugared = type->getUnqualifiedDesugaredType()) {
+              if (const auto *recordType = desugared->getAsStructureType()) {
+                if (recordType->getDecl()->getNameAsString() == parentStructName) {
+                  parentInstanceVarName = varDecl->getNameAsString();
+                  break;
+                }
+              }
+            }
+          }
+        }
 
         llvm::outs() << "PROCESSING FIELD DECL" << '\n'; 
         
-        GenerateVtabProcFunctionsForField(Ctx, Match.RecordDecl, Match.FieldDecl, openFile, parentStructName);
+        GenerateVtabProcFunctionsForField(Ctx, Match.RecordDecl, Match.FieldDecl, openFile, parentStructNam, parentInstanceVarName);
+        GenerateSerializeForField(Ctx, Match.RecordDecl, Match.VarDecl, Match.FieldDecl, openFile, parentStructName, parentInstanceVarName);
       } else {
         GenerateVtabProcFunctions(Ctx, Match.RecordDecl, Match.VarDecl, openFile);
+        GenerateSerialize(Ctx, Match.RecordDecl, Match.VarDecl, Match.FieldDecl, openFile);
       }
       
-      GenerateSerialize(Ctx, Match.RecordDecl, Match.VarDecl, Match.FieldDecl, openFile);
       openFile.close();
       first = false;
     }

--- a/lib/ASTConsumer.cc
+++ b/lib/ASTConsumer.cc
@@ -229,6 +229,7 @@ void GenerateIncludePaths(std::ofstream& file) {
       << "#include \"osdb_mod.h\"\n"
       << "#include \"sqlite3ext.h\"\n"
       << "#include \"vtab_common.h\"\n"
+      << "#include <dbsc/value.h>\n"
       << "\n"
       << "SQLITE_EXTENSION_INIT1\n\n";
 }
@@ -269,7 +270,7 @@ void GenerateColumnCopyFunctionForStruct(clang::ASTContext &Ctx,
 
   // Start generating the function that will copy the struct fields to columns
   file << "static int\n";
-  file << "copy_columns(struct " << DeclName << " *curEntry, osdb_value **columns, "
+  file << "copy_columns(struct " << DeclName << " *curEntry, dbsc_value **columns, "
        << "struct timespec *when, MD5_CTX *context) {\n\n";
 
   // Iterate through the fields of the struct and generate code for assigning values
@@ -278,15 +279,15 @@ void GenerateColumnCopyFunctionForStruct(clang::ASTContext &Ctx,
     auto fieldType = field->getType().getTypePtr(); 
     if (fieldType->isEnumeralType()) {
       file << "    columns[VT_" << DeclName << "_" << field->getNameAsString() << "] = ";
-      file << "new_osdb_int64(static_cast<int64_t>(curEntry->" 
+      file << "new_dbsc_int64(static_cast<int64_t>(curEntry->" 
              << field->getNameAsString() << "), context); // TODO: need better enum representation \n";
     } else if (fieldType->isIntegerType()) {
       file << "    columns[VT_" << DeclName << "_" << field->getNameAsString() << "] = ";
-      file << "new_osdb_int64(curEntry->" << field->getNameAsString() << ", context);\n";
+      file << "new_dbsc_int64(curEntry->" << field->getNameAsString() << ", context);\n";
     } else if (fieldType->isPointerType() && fieldType->getPointeeType()->isCharType()) {
       file << "    columns[VT_" << DeclName << "_" << field->getNameAsString() << "] = ";
       // Assuming string field is a char pointer
-      file << "new_osdb_text(curEntry->" << field->getNameAsString() << ", "
+      file << "new_dbsc_text(curEntry->" << field->getNameAsString() << ", "
            << "strlen(curEntry->" << field->getNameAsString() << ") + 1, context);\n";
     } else {
       file << "//    columns[VT_" << DeclName << "_" << field->getNameAsString() << "] = ";
@@ -371,7 +372,7 @@ void GenerateVtabProcFunctions(clang::ASTContext &Ctx,
        << "    snap->snap_table = new_osdb_table(VT_" << varName << "_NUM_COLUMNS" << ");\n"
        << "    MD5Init(&snap->context);\n\n"
        << "    while (prc) {\n"
-       << "        osdb_value **columns = new_osdb_columns(VT_" << varName << "_NUM_COLUMNS" << ");\n"
+       << "        dbsc_value **columns = new_osdb_columns(VT_" << varName << "_NUM_COLUMNS" << ");\n"
        << "        if (!columns) {\n"
        << "            return;\n"
        << "        }\n"
@@ -394,7 +395,7 @@ void GenerateVtabProcFunctions(clang::ASTContext &Ctx,
   file << "static int\nvtab_" << recordName << "_rowid(sqlite3_vtab_cursor *cur, sqlite_int64 *pRowid)\n"
        << "{\n"
        << "    common_cursor *pCur = (common_cursor *)cur;\n"
-       << "    osdb_value *pid_value = pCur->row->columns[VT_" << varName << "_PID];\n"
+       << "    dbsc_value *pid_value = pCur->row->columns[VT_" << varName << "_PID];\n"
        << "    *pRowid = pid_value->int64_value;\n"
        << "    printf(\"" << recordName << "_rowid was called, returning %lld\\n\", *pRowid);\n"
        << "    return SQLITE_OK;\n"

--- a/lib/ASTConsumer.cc
+++ b/lib/ASTConsumer.cc
@@ -900,7 +900,7 @@ void ASTConsumer::HandleTranslationUnit(clang::ASTContext &Ctx) {
         ;
       }
 
-      GenerateIncludePaths(parentStructName.empty() ? elementTypeName, openFile);
+      GenerateIncludePaths(parentStructName.empty() ? elementTypeName : parentStructName, openFile);
       if ("SLIST_HEAD" == Match.OpenBSDListDeclarationMacroName) {
         GenerateColumnCopyFunctionForStruct(Ctx, Match, "SLIST_ENTRY", openFile);
       } else if ("LIST_HEAD" == Match.OpenBSDListDeclarationMacroName) {

--- a/lib/ASTConsumer.cc
+++ b/lib/ASTConsumer.cc
@@ -258,6 +258,11 @@ void GenerateColumnCopyFunctionForStruct(clang::ASTContext &Ctx,
   auto lh_firstFieldRecordDecl =
       lh_firstFieldDecl->getType()->getPointeeType()->getAsRecordDecl();
 
+  const clang::FieldDecl *firstField = *RecordDecl->field_begin();
+  const clang::RecordDecl *elementTypeRecord =
+      firstField->getType()->getPointeeType()->getAsRecordDecl();
+  std::string elementTypeName = elementTypeRecord->getNameAsString(); // proc
+
   using namespace clang::ast_matchers;
   MatchFinder Finder;
   FieldDeclarationMatcherCallback FDMC;
@@ -283,7 +288,7 @@ void GenerateColumnCopyFunctionForStruct(clang::ASTContext &Ctx,
 
   // Start generating the function that will copy the struct fields to columns
   file << "static int\n";
-  file << "copy_columns(struct " << DeclName << " *curEntry, struct dbsc_value **columns, "
+  file << "copy_columns(struct " << elementTypeName << " *curEntry, struct dbsc_value **columns, "
        << "struct timespec *when, MD5_CTX *context) {\n\n";
 
   // Iterate through the fields of the struct and generate code for assigning values
@@ -488,8 +493,7 @@ void GenerateVtabProcFunctions(clang::ASTContext &Ctx,
        << "    osdb_snapshot_rotate((struct osdb_vtab *)pVtab, snap);\n"
        << "}\n\n";
 
-  // Write the Rowid function, replacing "proc" with the struct name
-  file << "static int\nvtab_" << elementTypeName << "_rowid(sqlite3_vtab_cursor *cur, sqlite_int64 *pRowid)\n"
+  file << "static int\n" << elementTypeName << "vtabRowid(sqlite3_vtab_cursor *cur, sqlite_int64 *pRowid)\n"
        << "{\n"
        << "    common_cursor *pCur = (common_cursor *)cur;\n"
        << "    struct dbsc_value *pid_value = pCur->row->columns[VT_" << varName << "_p_pid];\n"
@@ -499,7 +503,7 @@ void GenerateVtabProcFunctions(clang::ASTContext &Ctx,
        << "}\n\n";
 
   // Write the BestIndex function, replacing "proc" with the struct name
-  file << "static int\nvtab_" << elementTypeName << "_bestindex(sqlite3_vtab *tab, sqlite3_index_info *pIdxInfo)\n"
+  file << "static int\n" << elementTypeName << "vtabBestIndex(sqlite3_vtab *tab, sqlite3_index_info *pIdxInfo)\n"
        << "{\n"
        << "    pIdxInfo->estimatedCost = (double)10;\n"
        << "    pIdxInfo->estimatedRows = 10;\n"
@@ -507,7 +511,7 @@ void GenerateVtabProcFunctions(clang::ASTContext &Ctx,
        << "}\n\n";
 
   // Write the Update function, replacing "proc" with the struct name
-  file << "static int\nvtab_" << elementTypeName << "_update(sqlite3_vtab *pVTab, int argc, sqlite3_value **argv, sqlite_int64 *pRowid)\n"
+  file << "static int\n" << elementTypeName << "vtabUpdate(sqlite3_vtab *pVTab, int argc, sqlite3_value **argv, sqlite_int64 *pRowid)\n"
        << "{\n"
        << "    struct timespec when;\n"
        << "    nanotime(&when);\n"

--- a/lib/ASTConsumer.cc
+++ b/lib/ASTConsumer.cc
@@ -222,14 +222,27 @@ std::ofstream OpenFile(OpenBSDQueueMacroDecl LIST_HEADDecl) {
   return file; 
 }
 
-void GenerateIncludePaths(std::ofstream& file) {
+void GenerateIncludePaths(const clang::RecordDecl *recordDecl, std::ofstream& file) {
+  const clang::FieldDecl *firstField = *recordDecl->field_begin();
+  const clang::RecordDecl *elementTypeRecord =
+      firstField->getType()->getPointeeType()->getAsRecordDecl();
+  std::string elementTypeName = elementTypeRecord->getNameAsString(); // proc
+
   file << "#include <sys/types.h>\n"
-      << "\n"
-      << "#include \"osdb.h\"\n"
-      << "#include \"osdb_mod.h\"\n"
-      << "#include \"sqlite3ext.h\"\n"
-      << "#include \"vtab_common.h\"\n"
-      << "#include <dbsc/value.h>\n"
+       << "#include <sys/systm.h>\n"
+       << "#include <sys/libkern.h>\n"
+       << "#include <sys/malloc.h>\n"
+       << "#include <sys/" << elementTypeName << ".h>\n"
+       << "#include <sys/signal.h>\n"
+       << "#include <sys/tty.h>\n"
+       << "\n"
+       << "#include <dbsc/value.h>"
+       << "\n"
+       << "#include \"osdb.h\"\n"
+       << "#include \"osdb_mod.h\"\n"
+       << "#include \"sqlite3ext.h\"\n"
+       << "#include \"vtab_common.h\"\n"
+       << "#include \"vtab_" << elementTypeName << ".h\"\n"
       << "\n"
       << "SQLITE_EXTENSION_INIT1\n\n";
 }
@@ -300,6 +313,91 @@ void GenerateColumnCopyFunctionForStruct(clang::ASTContext &Ctx,
 
 }
 
+void GenerateSerialize(clang::ASTContext &Ctx,
+                       const clang::RecordDecl *recordDecl,
+                       const clang::VarDecl *varDecl,
+                       std::ofstream &file) {
+  std::string varName = varDecl->getNameAsString();  // Get the allproc variable name
+  const clang::FieldDecl *firstField = *recordDecl->field_begin();
+  const clang::RecordDecl *elementTypeRecord =
+      firstField->getType()->getPointeeType()->getAsRecordDecl();
+  std::string elementTypeName = elementTypeRecord->getNameAsString(); // proc
+
+  const std::string tableName = std::string("all_") + elementTypeName + "s";
+
+  file << "void vtab_" << elementTypeName << "_serialize(sqlite3 *real_db, struct timespec when) {\n";
+  file << "    struct " << elementTypeName << " *entry = LIST_FIRST(&" << varName << ");\n\n";
+
+  // === Create Table ===
+  file << "    const char *create_stmt =\n";
+  file << "        \"CREATE TABLE " << tableName << " (";
+
+  bool first = true;
+  std::vector<std::string> handledFields;
+  for (const auto *field : elementTypeRecord->fields()) {
+    auto fieldType = field->getType().getTypePtr();
+    if (!(fieldType->isEnumeralType() || fieldType->isIntegerType() ||
+          (fieldType->isPointerType() && fieldType->getPointeeType()->isCharType())))
+      continue;
+
+    if (!first) file << ", ";
+    first = false;
+
+    std::string fieldName = field->getNameAsString();
+    handledFields.push_back(fieldName);
+
+    file << fieldName << " ";
+    if (fieldType->isEnumeralType() || fieldType->isIntegerType()) {
+      file << "INTEGER";
+    } else {
+      file << "TEXT";
+    }
+  }
+  file << ")\";\n";
+  file << "    char *errMsg = NULL;\n";
+  file << "    sqlite3_exec(real_db, create_stmt, NULL, NULL, &errMsg);\n\n";
+
+  // === Insert Statement ===
+  file << "    const char *insert_stmt = \"INSERT INTO " << tableName << " VALUES (";
+  for (size_t i = 0; i < handledFields.size(); ++i) {
+    if (i > 0) file << ", ";
+    file << "?";
+  }
+  file << ")\";\n";
+  file << "    sqlite3_stmt *stmt = NULL;\n";
+  file << "    sqlite3_prepare_v2(real_db, insert_stmt, -1, &stmt, NULL);\n\n";
+
+  // === While loop over linked list ===
+  file << "    while (entry) {\n";
+  file << "        osdb_value **columns = new_osdb_columns(VT_" << varName << "_NUM_COLUMNS);\n";
+
+  file << "        int bindIndex = 1;\n";
+  for (const auto &fieldName : handledFields) {
+    file << "        {\n";
+    file << "            osdb_value *val = columns[VT" << varName << "_" << fieldName << "];\n";
+    file << "            switch (val->type) {\n";
+    file << "                case INT64:\n";
+    file << "                    sqlite3_bind_int64(stmt, bindIndex++, val->int64_value);\n";
+    file << "                    break;\n";
+    file << "                case TEXT:\n";
+    file << "                    sqlite3_bind_text(stmt, bindIndex++, val->text_value, -1, SQLITE_STATIC);\n";
+    file << "                    break;\n";
+    file << "                default:\n";
+    file << "                    sqlite3_bind_null(stmt, bindIndex++);\n";
+    file << "                    break;\n";
+    file << "            }\n";
+    file << "        }\n";
+  }
+
+  file << "        sqlite3_step(stmt);\n";
+  file << "        sqlite3_reset(stmt);\n";
+  file << "        entry = LIST_NEXT(entry,  p_list);\n";
+  file << "    }\n\n";
+
+  file << "    sqlite3_finalize(stmt);\n";
+  file << "}\n\n";
+}
+
 void GenerateVtabModule(std::ofstream& file, const std::string& recordName) {
     file << "/*\n** This following structure defines all the methods for the\n"
          << "** virtual table.\n*/\n";
@@ -347,12 +445,11 @@ void GenerateVtabProcFunctions(clang::ASTContext &Ctx,
                                const clang::RecordDecl *recordDecl,
                                const clang::VarDecl *varDecl,
                                std::ofstream& file) {
-  std::string recordName = recordDecl->getNameAsString();  // Get the struct type name
   std::string varName = varDecl->getNameAsString();  // Get the allproc variable name
   const clang::FieldDecl *firstField = *recordDecl->field_begin();
   const clang::RecordDecl *elementTypeRecord =
       firstField->getType()->getPointeeType()->getAsRecordDecl();
-  std::string elementTypeName = elementTypeRecord->getNameAsString();
+  std::string elementTypeName = elementTypeRecord->getNameAsString(); // proc
 
   // Write the lock and unlock functions, replacing "proc" with the struct name
   file << "void\nvtab_" << elementTypeName << "_lock(void)\n{\n"
@@ -395,7 +492,7 @@ void GenerateVtabProcFunctions(clang::ASTContext &Ctx,
   file << "static int\nvtab_" << elementTypeName << "_rowid(sqlite3_vtab_cursor *cur, sqlite_int64 *pRowid)\n"
        << "{\n"
        << "    common_cursor *pCur = (common_cursor *)cur;\n"
-       << "    struct dbsc_value *pid_value = pCur->row->columns[VT_" << varName << "_PID];\n"
+       << "    struct dbsc_value *pid_value = pCur->row->columns[VT_" << varName << "_p_pid];\n"
        << "    *pRowid = pid_value->int64_value;\n"
        << "    printf(\"" << elementTypeName << "_rowid was called, returning %lld\\n\", *pRowid);\n"
        << "    return SQLITE_OK;\n"
@@ -535,7 +632,7 @@ void ASTConsumer::HandleTranslationUnit(clang::ASTContext &Ctx) {
       if(!openFile.is_open()) {
         continue; 
       }
-      GenerateIncludePaths(openFile);
+      GenerateIncludePaths(Match.RecordDecl, openFile);
       /* TODO(Brent): Add printers for the other declaration macros. */
       if ("SLIST_HEAD" == Match.OpenBSDListDeclarationMacroName) {
         GenerateColumnCopyFunctionForStruct(Ctx, Match, "SLIST_ENTRY", openFile);
@@ -549,6 +646,7 @@ void ASTConsumer::HandleTranslationUnit(clang::ASTContext &Ctx) {
         GenerateColumnCopyFunctionForStruct(Ctx, Match, "STAILQ_ENTRY", openFile);
       } 
       GenerateVtabProcFunctions(Ctx, Match.RecordDecl, Match.VarDecl, openFile);
+      GenerateSerialize(Ctx, Match.RecordDecl, Match.VarDecl, openFile);
       openFile.close();
       first = false;
     }

--- a/lib/ASTConsumer.cc
+++ b/lib/ASTConsumer.cc
@@ -327,8 +327,7 @@ void GenerateSerialize(clang::ASTContext &Ctx,
   int colCount = 0;
   for (const auto *field : elementTypeRecord->fields()) {
     auto fieldType = field->getType().getTypePtr();
-    if (!(fieldType->isEnumeralType() || fieldType->isIntegerType() ||
-          (fieldType->isPointerType() && fieldType->getPointeeType()->isCharType())))
+    if (!(fieldType->isEnumeralType() || fieldType->isIntegerType() || fieldType->isPointerType()))
       continue;
 
     if (!first) file << ", ";
@@ -338,9 +337,10 @@ void GenerateSerialize(clang::ASTContext &Ctx,
     colCount++;
 
     file << fieldName << " ";
-    if (fieldType->isEnumeralType() || fieldType->isIntegerType()) {
+    if (fieldType->isEnumeralType() || fieldType->isIntegerType() || (fieldType->isPointerType() && !fieldType->getPointeeType()->isCharType())) {
       file << "INTEGER";
-    } else {
+    }
+    else {
       file << "TEXT";
     }
   }
@@ -368,7 +368,7 @@ void GenerateSerialize(clang::ASTContext &Ctx,
       continue;
 
     std::string fieldName = field->getNameAsString();
-    if (fieldType->isEnumeralType() || fieldType->isIntegerType()) {
+    if (fieldType->isEnumeralType() || fieldType->isIntegerType() || (fieldType->isPointerType() && !fieldType->getPointeeType()->isCharType())) {
       file << "           sqlite3_bind_int64(stmt, bindIndex++, entry->" << fieldName << ");\n";
     } else {
       file << "           sqlite3_bind_text(stmt, bindIndex++, entry->" << fieldName << ", -1, SQLITE_TRANSIENT);\n";

--- a/lib/ASTConsumer.cc
+++ b/lib/ASTConsumer.cc
@@ -27,21 +27,10 @@ static const std::array<std::string, 6> OpenBSDQueueMacroDeclNames = {
 /* Represents a variable declaration whose type was declared using one of the
  * OpenBSD macros defined in `src/sys/sys/queue.h`. */
 struct OpenBSDQueueMacroDecl {
-  /* The name of the HEAD() macro invoked to create this declaration. One of:
-   * - SLIST_HEAD
-   * - LIST_HEAD
-   * - SIMPLEQ_HEAD
-   * - XSIMPLEQ_HEAD
-   * - TAILQ_HEAD
-   * - STAILQ_HEAD
-   * */
   std::string OpenBSDListDeclarationMacroName;
-
-  /* The record decl that this macro invocation declared. */
   const clang::RecordDecl *RecordDecl;
-
-  /* The variable that this macro invocation declared the type of. */
-  const clang::VarDecl *VarDecl;
+  const clang::VarDecl *VarDecl;    // non-null if this came from a varDecl
+  const clang::FieldDecl *FieldDecl; // non-null if this came from a fieldDecl
 };
 
 /* A matcher callback that collects FieldDecls. */
@@ -64,7 +53,7 @@ public:
 class OpenBSDListMacroDeclMatchCallback
     : public clang::ast_matchers::MatchFinder::MatchCallback {
 public:
-  /* The name of the OpenBSD list declaration macro that this macro should be
+ /* The name of the OpenBSD list declaration macro that this macro should be
    * collecting matches for. */
   std::string OpenBSDListDeclarationMacroName;
 
@@ -76,10 +65,14 @@ public:
 
   virtual void
   run(const clang::ast_matchers::MatchFinder::MatchResult &Result) final {
-    if (const auto VarDecl = Result.Nodes.getNodeAs<clang::VarDecl>("root")) {
-      const auto RecordDecl = VarDecl->getType()->getAsRecordDecl();
-      OpenBSDQueueMacroDecl MacroDecl{OpenBSDListDeclarationMacroName,
-                                          RecordDecl, VarDecl};
+    if (const auto *VD = Result.Nodes.getNodeAs<clang::VarDecl>("root")) {
+      const auto *RD = VD->getType()->getAsRecordDecl();
+      OpenBSDQueueMacroDecl MacroDecl{OpenBSDListDeclarationMacroName, RD, VD, nullptr};
+      Matches.push_back(MacroDecl);
+    } else if (const auto *FD = Result.Nodes.getNodeAs<clang::FieldDecl>("root")) {
+      // For a FieldDecl, get the record that was produced by the macro expansion.
+      const auto *RD = FD->getType()->getPointeeType()->getAsRecordDecl();
+      OpenBSDQueueMacroDecl MacroDecl{OpenBSDListDeclarationMacroName, RD, nullptr, FD};
       Matches.push_back(MacroDecl);
     }
   }
@@ -94,26 +87,14 @@ FindOpenBSDQueueMacroDecls(clang::ASTContext &Ctx,
   using namespace clang::ast_matchers;
   MatchFinder Finder;
   OpenBSDListMacroDeclMatchCallback Callback(OpenBSDListDeclarationMacroName);
-  /* This matcher does most of the work. Here we are telling Clang to find all
-   * variable declarations having a type that is a record decl (e.g., a struct),
-   * whose declaration was expanded from a macro with the name
-   * `OpenBSDListDeclarationMacroName`. We then bind the matched declaration to
-   * the name "root" for the callback (defined above) to hook into.
-   *
-   * For instance, assuming "SLIST_HEAD" == OpenBSDListDeclarationMacroName,
-   * then for this line of code:
-   *
-   * ```c
-   * SLIST_HEAD(slisthead, entry) head = SLIST_HEAD_INITIALIZER(head);
-   * ```
-   *
-   * The matcher would match the declaration for `head`, and bind it to the name
-   * "root".
-   */
-  DeclarationMatcher Matcher =
+  DeclarationMatcher Matcher = anyOf(
       varDecl(hasType(recordDecl(isExpandedFromMacro(
                   std::string(OpenBSDListDeclarationMacroName)))))
-          .bind("root");
+          .bind("root"),
+      fieldDecl(hasType(recordDecl(isExpandedFromMacro(
+                  std::string(OpenBSDListDeclarationMacroName)))))
+          .bind("root")
+  );
   Finder.addMatcher(Matcher, &Callback);
   Finder.matchAST(Ctx);
   return Callback.Matches;
@@ -511,8 +492,8 @@ void GenerateVtabProcFunctions(clang::ASTContext &Ctx,
        << "    return SQLITE_OK;\n"
        << "}\n\n";
   
-  file << "extern int kern_cpuset_setaffinity(struct thread *td, cpulevel_t level, cpuwhich_t which, id_t id, cpuset_t *mask);\n"
-  file << "extern int cpuset_setproc(pid_t pid, struct cpuset *set, cpuset_t *mask, struct domainset *domain, bool rebase);\n\n"
+  file << "extern int kern_cpuset_setaffinity(struct thread *td, cpulevel_t level, cpuwhich_t which, id_t id, cpuset_t *mask);\n";
+  file << "extern int cpuset_setproc(pid_t pid, struct cpuset *set, cpuset_t *mask, struct domainset *domain, bool rebase);\n\n";
 
   // Write the Update function, replacing "proc" with the struct name
   file << "static int\n" << elementTypeName << "vtabUpdate(sqlite3_vtab *pVTab, int argc, sqlite3_value **argv, sqlite_int64 *pRowid)\n"
@@ -553,6 +534,115 @@ void GenerateVtabProcFunctions(clang::ASTContext &Ctx,
   // Call the function to generate the sqlite3_module with the correct struct name
   GenerateVtabModule(file, elementTypeName);
 }
+
+void GenerateVtabProcFunctionsForField(clang::ASTContext &Ctx,
+                                       const clang::RecordDecl *recordDecl,
+                                       const clang::FieldDecl *fieldDecl,
+                                       std::ofstream &file,
+                                       const std::string &parentStructName) {
+  std::string varName = fieldDecl->getNameAsString();  // Get the allproc variable name
+  const clang::FieldDecl *firstField = *recordDecl->field_begin();
+  const clang::RecordDecl *elementTypeRecord =
+      firstField->getType()->getPointeeType()->getAsRecordDecl();
+  std::string elementTypeName = elementTypeRecord->getNameAsString(); // proc
+
+  // Write the lock and unlock functions, replacing "proc" with the struct name
+  file << "void\nvtab_" << elementTypeName << "_lock(void)\n{\n"
+       << "    sx_slock(&" << varName << "_lock);\n"
+       << "}\n\n";
+
+  file << "void\nvtab_" << elementTypeName << "_unlock(void)\n{\n"
+       << "    sx_sunlock(&" << varName << "_lock);\n"
+       << "}\n\n";
+
+  // Write the snapshot function, replacing "proc" with the struct name
+  file << "void\nvtab_" << elementTypeName << "_snapshot(sqlite3_vtab *pVtab, struct timespec when)\n"
+       << "{\n"
+       << "    struct " << elementTypeName << " *prc = LIST_FIRST(&" << varName << ");\n\n"
+       << "    osdb_snap *snap = malloc(sizeof(struct osdb_snap), M_SQLITE, M_WAITOK);\n"
+       << "    snap->when = when;\n"
+       << "    snap->snap_table = new_osdb_table(VT_" << varName << "_NUM_COLUMNS" << ");\n"
+       << "    MD5Init(&snap->context);\n\n"
+       << "    while (prc) {\n"
+       << "        struct dbsc_value **columns = new_osdb_columns(VT_" << varName << "_NUM_COLUMNS" << ");\n"
+       << "        if (!columns) {\n"
+       << "            return;\n"
+       << "        }\n"
+       << "        copy_columns(prc, columns, &snap->when, &snap->context);\n"
+       << "        osdb_table_push(snap->snap_table, columns);\n"
+       << "        prc = LIST_NEXT(prc, p_list);\n"
+       << "    }\n\n"
+       << "    MD5Final(snap->digest, &snap->context);\n"
+       << "#ifdef DEBUG\n"
+       << "    printf(\"" << elementTypeName << " digest: \");\n"
+       << "    for (size_t i = 0; i < 16; i++) {\n"
+       << "        printf(\"%02hhx\", snap->digest[i]);\n"
+       << "    }\n"
+       << "    printf(\"\\n\");\n"
+       << "#endif\n"
+       << "    osdb_snapshot_rotate((struct osdb_vtab *)pVtab, snap);\n"
+       << "}\n\n";
+
+  file << "static int\n" << elementTypeName << "vtabRowid(sqlite3_vtab_cursor *cur, sqlite_int64 *pRowid)\n"
+       << "{\n"
+       << "    common_cursor *pCur = (common_cursor *)cur;\n"
+       << "    struct dbsc_value *pid_value = pCur->row->columns[VT_" << varName << "_p_pid];\n"
+       << "    *pRowid = pid_value->int64_value;\n"
+       << "    printf(\"" << elementTypeName << "_rowid was called, returning %lld\\n\", *pRowid);\n"
+       << "    return SQLITE_OK;\n"
+       << "}\n\n";
+
+  // Write the BestIndex function, replacing "proc" with the struct name
+  file << "static int\n" << elementTypeName << "vtabBestIndex(sqlite3_vtab *tab, sqlite3_index_info *pIdxInfo)\n"
+       << "{\n"
+       << "    pIdxInfo->estimatedCost = (double)10;\n"
+       << "    pIdxInfo->estimatedRows = 10;\n"
+       << "    return SQLITE_OK;\n"
+       << "}\n\n";
+  
+  file << "extern int kern_cpuset_setaffinity(struct thread *td, cpulevel_t level, cpuwhich_t which, id_t id, cpuset_t *mask);\n";
+  file << "extern int cpuset_setproc(pid_t pid, struct cpuset *set, cpuset_t *mask, struct domainset *domain, bool rebase);\n\n";
+
+  // Write the Update function, replacing "proc" with the struct name
+  file << "static int\n" << elementTypeName << "vtabUpdate(sqlite3_vtab *pVTab, int argc, sqlite3_value **argv, sqlite_int64 *pRowid)\n"
+       << "{\n"
+       << "    struct timespec when;\n"
+       << "    nanotime(&when);\n"
+       << "    vtab_" << elementTypeName << "_snapshot(pVTab, when);\n"
+       << "    if (osdb_snapshot_compare((struct osdb_vtab *)pVTab) <= 0) {\n"
+       << "#ifdef DEBUG\n"
+       << "        printf(\"" << elementTypeName << " digest mismatch: UPDATE failed\\n\");\n"
+       << "#endif\n"
+       << "        return SQLITE_ABORT;\n"
+       << "    }\n\n"
+       << "    if ((argc == 1) && (argv[0] != NULL)) {\n"
+       << "        int p_pid = sqlite3_value_int64(argv[0]);\n"
+       << "#ifdef DEBUG\n"
+       << "        printf(\"argc %d argv[0] %d, rowID, %lld\\n\", argc, p_pid, *pRowid);\n"
+       << "        printf(\"Killing PID %d.\\n\", p_pid);\n"
+       << "#endif\n"
+       << "        kern_kill(curthread, p_pid, SIGKILL);\n"
+       << "        return SQLITE_OK;\n"
+       << "    }\n\n"
+       << "    if ((argc > 1) && (sqlite3_value_type(argv[0]) != SQLITE_NULL)) {\n"
+       << "        int core = sqlite3_value_int64(argv[2]);\n"
+       << "        int pid = sqlite3_value_int64(argv[5]);\n"
+       << "        cpuset_t *mask = malloc(sizeof(cpuset_t), M_TEMP, M_WAITOK | M_ZERO);\n"
+       << "#ifdef DEBUG\n"
+       << "        int row = sqlite3_value_int64(argv[0]);\n"
+       << "        printf(\"UPDATE row %d core %d pid %d\\n\", row, core, pid);\n"
+       << "#endif\n"
+       << "        CPU_SET(core, mask);\n"
+       << "        cpuset_setproc(pid, NULL, mask, NULL, false);\n"
+       << "        free(mask, M_TEMP);\n"
+       << "    }\n\n"
+       << "    return SQLITE_OK;\n"
+       << "}\n\n";
+
+  // Call the function to generate the sqlite3_module with the correct struct name
+  GenerateVtabModule(file, elementTypeName);
+}
+
 
 void LogStructRelationships(const clang::RecordDecl *RecordDecl) {
   std::ofstream file("/usr/src/table_src/struct_relationships.txt", std::ios::app);
@@ -618,42 +708,49 @@ plugin. */
 void ASTConsumer::HandleTranslationUnit(clang::ASTContext &Ctx) {
   std::unordered_set<const clang::RecordDecl*> ProcessedRecords;
   auto first = true;
-  /* Run the printer on every kind of OpenBSD list macro. */
   for (const auto &OpenBSDQueueMacroDeclName : OpenBSDQueueMacroDeclNames) {
     auto Matches = FindOpenBSDQueueMacroDecls(Ctx, OpenBSDQueueMacroDeclName);
     for (auto Match : Matches) {
-      if(ProcessedRecords.find(Match.RecordDecl) != ProcessedRecords.end()) {
-        llvm::outs() << "skipped declaration" << '\n'; 
+      if (ProcessedRecords.find(Match.RecordDecl) != ProcessedRecords.end()) {
+        llvm::outs() << "skipped declaration" << '\n';
         continue;
       }
       ProcessedRecords.insert(Match.RecordDecl);
       LogStructRelationships(Match.RecordDecl);
-      /* Print a banner to separate different lists.
-       *
-       * TODO(Brent): Change the output format to something easily
-       * machine-readable like JSON.
-       */
       if (!first) {
         llvm::outs() << std::string(80, '#') << '\n';
       }
       std::ofstream openFile = OpenFile(Match);
-      if(!openFile.is_open()) {
-        continue; 
+      if (!openFile.is_open()) {
+        continue;
       }
       GenerateIncludePaths(Match.RecordDecl, openFile);
-      /* TODO(Brent): Add printers for the other declaration macros. */
       if ("SLIST_HEAD" == Match.OpenBSDListDeclarationMacroName) {
         GenerateColumnCopyFunctionForStruct(Ctx, Match, "SLIST_ENTRY", openFile);
-      } else if("LIST_HEAD" == Match.OpenBSDListDeclarationMacroName) {
+      } else if ("LIST_HEAD" == Match.OpenBSDListDeclarationMacroName) {
         GenerateColumnCopyFunctionForStruct(Ctx, Match, "LIST_ENTRY", openFile);
-      } else if("TAILQ_HEAD" == Match.OpenBSDListDeclarationMacroName) {
-        llvm::outs() << "TAILQ HEAD DECLARATION" << '\n'; 
+      } else if ("TAILQ_HEAD" == Match.OpenBSDListDeclarationMacroName) {
+        llvm::outs() << "TAILQ HEAD DECLARATION" << '\n';
         GenerateColumnCopyFunctionForStruct(Ctx, Match, "TAILQ_ENTRY", openFile);
-      } else if("STAILQ_HEAD" == Match.OpenBSDListDeclarationMacroName) {
-        llvm::outs() << "STAILQ HEAD DECLARATION" << '\n'; 
+      } else if ("STAILQ_HEAD" == Match.OpenBSDListDeclarationMacroName) {
+        llvm::outs() << "STAILQ HEAD DECLARATION" << '\n';
         GenerateColumnCopyFunctionForStruct(Ctx, Match, "STAILQ_ENTRY", openFile);
-      } 
-      GenerateVtabProcFunctions(Ctx, Match.RecordDecl, Match.VarDecl, openFile);
+      }
+      
+      // Call the appropriate vtab function based on whether we matched a varDecl or a fieldDecl.
+      if (Match.FieldDecl) {
+        // Retrieve the name of the parent struct that contains this field.
+        std::string parentStructName;
+        if (const auto *parent = llvm::dyn_cast<clang::RecordDecl>(Match.FieldDecl->getParent())) {
+          parentStructName = parent->getNameAsString();
+        }
+        GenerateVtabProcFunctionsForField(Ctx, Match.RecordDecl, Match.FieldDecl, openFile, parentStructName);
+      } else {
+        GenerateVtabProcFunctions(Ctx, Match.RecordDecl, Match.VarDecl, openFile);
+      }
+      
+      // Note: GenerateSerialize still expects a VarDecl. If needed, you may also want to update
+      // GenerateSerialize to handle field declarations separately.
       GenerateSerialize(Ctx, Match.RecordDecl, Match.VarDecl, openFile);
       openFile.close();
       first = false;

--- a/lib/ASTConsumer.cc
+++ b/lib/ASTConsumer.cc
@@ -205,6 +205,43 @@ void PrintListIteratorForSLIST_HEADDecl(clang::ASTContext &Ctx,
   llvm::outs() << "    }\n}\n";
 }
 
+/* Prints the list iterator function for a declaration declared using the
+ * LIST_HEAD() macro. */
+void PrintListIteratorForLIST_HEADDecl(clang::ASTContext &Ctx,
+                                        OpenBSDQueueMacroDecl LIST_HEADDecl) {
+  auto DeclName = LIST_HEADDecl.VarDecl->getNameAsString();
+  auto RecordDecl = LIST_HEADDecl.RecordDecl;
+  const clang::FieldDecl *lh_firstFieldRecordDeclLIST_ENTRYField;
+  auto lh_firstFieldDecl = *RecordDecl->field_begin();
+  auto lh_firstFieldRecordDecl =
+      lh_firstFieldDecl->getType()->getPointeeType()->getAsRecordDecl();
+
+  /* Find the field in the entry declaration that was expanded from
+   * LIST_ENTRY(). */
+  using namespace clang::ast_matchers;
+  MatchFinder Finder;
+  FieldDeclarationMatcherCallback FDMC;
+  DeclarationMatcher LIST_ENTRYMatcher = recordDecl(has(
+      fieldDecl(
+          hasType(recordDecl(isExpandedFromMacro(std::string("LIST_ENTRY")))))
+          .bind("root")));
+  Finder.addMatcher(LIST_ENTRYMatcher, &FDMC);
+  Finder.match(*lh_firstFieldRecordDecl, Ctx);
+  /* LIST_ENTRY() should be called exactly once in the declaration of list's
+   * entry type. */
+  assert(1 == FDMC.Matches.size());
+  lh_firstFieldRecordDeclLIST_ENTRYField = FDMC.Matches.front();
+
+  llvm::outs() << std::format(
+      "{{\n    struct {} * __openbsd_list_iterator;\n    "
+      "LIST_FOREACH(__openbsd_list_iterator, &{}, {}) {{\n",
+      lh_firstFieldRecordDecl->getNameAsString(), DeclName,
+      lh_firstFieldRecordDeclLIST_ENTRYField->getNameAsString());
+  PrintPrintersForRecordDeclFields(8u, "__openbsd_list_iterator",
+                                   lh_firstFieldRecordDecl);
+  llvm::outs() << "    }\n}\n";
+}
+
 /* We only define this constructor because Clang requires it. */
 ASTConsumer::ASTConsumer(clang::CompilerInstance &CI) { (void)CI; }
 
@@ -227,6 +264,8 @@ void ASTConsumer::HandleTranslationUnit(clang::ASTContext &Ctx) {
       /* TODO(Brent): Add printers for the other declaration macros. */
       if ("SLIST_HEAD" == Match.OpenBSDListDeclarationMacroName) {
         PrintListIteratorForSLIST_HEADDecl(Ctx, Match);
+      } else if("LIST_HEAD" == Match.OpenBSDListDeclarationMacroName) {
+        PrintListIteratorForLIST_HEADDecl(Ctx, Match);
       }
       first = false;
     }

--- a/lib/ASTConsumer.cc
+++ b/lib/ASTConsumer.cc
@@ -11,6 +11,8 @@
 #include <format>
 #include <string>
 #include <vector>
+#include <unordered_set>
+#include <fstream>
 
 namespace openbsd_list_macro_printer {
 
@@ -139,10 +141,8 @@ FindOpenBSDQueueMacroDecls(clang::ASTContext &Ctx,
  *     printf("%s", np->b);
  * ```
  */
-void PrintPrintersForRecordDeclFields(unsigned indent,
-                                      std::string RecordDeclVarName,
-                                      const clang::RecordDecl *RecordDecl) {
-
+void PrintPrintersForRecordDeclFields(unsigned indent, std::string RecordDeclVarName,
+                                      const clang::RecordDecl *RecordDecl, std::ofstream &file) {
   for (const auto FieldDecl : RecordDecl->fields()) {
     std::string FormatSpecifier;
     std::string PrintfArgument =
@@ -151,64 +151,22 @@ void PrintPrintersForRecordDeclFields(unsigned indent,
     if (Type->isPointerType() && Type->getPointeeType()->isCharType()) {
       FormatSpecifier = "%s";
     }
-    /* If we didn't already determine a format specifier for this type, try to
-     * do so now. */
     if (Type->isUnsignedIntegerType()) {
       FormatSpecifier = "%u";
     } else if (Type->isSignedIntegerType()) {
       FormatSpecifier = "%d";
     }
-    /* If we inferred a type for this field, print out its printer. */
+
     if (!FormatSpecifier.empty()) {
-      llvm::outs() << std::format("{}printf(\"{}\", {});\n",
-                                  std::string(indent, ' '), FormatSpecifier,
-                                  PrintfArgument);
+      file << std::string(indent, ' ') << std::format("printf(\"{}\", {});\n",
+                                  FormatSpecifier, PrintfArgument);
     }
   }
 }
 
-/* Prints the list iterator function for a declaration declared using the
- * SLIST_HEAD() macro. */
-void PrintListIteratorForSLIST_HEADDecl(clang::ASTContext &Ctx,
-                                        OpenBSDQueueMacroDecl SLIST_HEADDecl) {
-  auto DeclName = SLIST_HEADDecl.VarDecl->getNameAsString();
-  auto RecordDecl = SLIST_HEADDecl.RecordDecl;
-  const clang::FieldDecl *slh_firstFieldRecordDeclSLIST_ENTRYField;
-  auto slh_firstFieldDecl = *RecordDecl->field_begin();
-  auto slh_firstFieldRecordDecl =
-      slh_firstFieldDecl->getType()->getPointeeType()->getAsRecordDecl();
-
-  /* Find the field in the entry declaration that was expanded from
-   * SLIST_ENTRY(). */
-  using namespace clang::ast_matchers;
-  MatchFinder Finder;
-  FieldDeclarationMatcherCallback FDMC;
-  DeclarationMatcher SLIST_ENTRYMatcher = recordDecl(has(
-      fieldDecl(
-          hasType(recordDecl(isExpandedFromMacro(std::string("SLIST_ENTRY")))))
-          .bind("root")));
-  Finder.addMatcher(SLIST_ENTRYMatcher, &FDMC);
-  Finder.match(*slh_firstFieldRecordDecl, Ctx);
-  /* SLIST_ENTRY() should be called exactly once in the declaration of list's
-   * entry type. */
-  assert(1 == FDMC.Matches.size());
-  slh_firstFieldRecordDeclSLIST_ENTRYField = FDMC.Matches.front();
-
-  // NOTE(Brent): We assume that this is a decl of a struct.
-  llvm::outs() << std::format(
-      "{{\n    struct {} * __openbsd_list_iterator;\n    "
-      "SLIST_FOREACH(__openbsd_list_iterator, &{}, {}) {{\n",
-      slh_firstFieldRecordDecl->getNameAsString(), DeclName,
-      slh_firstFieldRecordDeclSLIST_ENTRYField->getNameAsString());
-  PrintPrintersForRecordDeclFields(8u, "__openbsd_list_iterator",
-                                   slh_firstFieldRecordDecl);
-  llvm::outs() << "    }\n}\n";
-}
-
-/* Prints the list iterator function for a declaration declared using the
- * LIST_HEAD() macro. */
 void PrintListIteratorForLIST_HEADDecl(clang::ASTContext &Ctx,
-                                        OpenBSDQueueMacroDecl LIST_HEADDecl) {
+                                       OpenBSDQueueMacroDecl LIST_HEADDecl,
+                                       const std::string& entryName) {
   auto DeclName = LIST_HEADDecl.VarDecl->getNameAsString();
   auto RecordDecl = LIST_HEADDecl.RecordDecl;
   const clang::FieldDecl *lh_firstFieldRecordDeclLIST_ENTRYField;
@@ -216,30 +174,40 @@ void PrintListIteratorForLIST_HEADDecl(clang::ASTContext &Ctx,
   auto lh_firstFieldRecordDecl =
       lh_firstFieldDecl->getType()->getPointeeType()->getAsRecordDecl();
 
-  /* Find the field in the entry declaration that was expanded from
-   * LIST_ENTRY(). */
+  // Open a file based on the record name
+  std::ofstream file(std::string{"/usr/src/table_src/"} + DeclName + "_tbl.c");
+
+  if (!file.is_open()) {
+    llvm::errs() << "Error opening file: " << DeclName + "_tbl.c" << "\n";
+    return;
+  }
+
   using namespace clang::ast_matchers;
   MatchFinder Finder;
   FieldDeclarationMatcherCallback FDMC;
   DeclarationMatcher LIST_ENTRYMatcher = recordDecl(has(
       fieldDecl(
-          hasType(recordDecl(isExpandedFromMacro(std::string("LIST_ENTRY")))))
+          hasType(recordDecl(isExpandedFromMacro(std::string(entryName)))))
           .bind("root")));
   Finder.addMatcher(LIST_ENTRYMatcher, &FDMC);
   Finder.match(*lh_firstFieldRecordDecl, Ctx);
-  /* LIST_ENTRY() should be called exactly once in the declaration of list's
-   * entry type. */
   assert(1 == FDMC.Matches.size());
   lh_firstFieldRecordDeclLIST_ENTRYField = FDMC.Matches.front();
 
-  llvm::outs() << std::format(
+  llvm::outs() << "Processing file " << DeclName << '\n';
+
+  file << std::format(
       "{{\n    struct {} * __openbsd_list_iterator;\n    "
       "LIST_FOREACH(__openbsd_list_iterator, &{}, {}) {{\n",
       lh_firstFieldRecordDecl->getNameAsString(), DeclName,
       lh_firstFieldRecordDeclLIST_ENTRYField->getNameAsString());
+
   PrintPrintersForRecordDeclFields(8u, "__openbsd_list_iterator",
-                                   lh_firstFieldRecordDecl);
-  llvm::outs() << "    }\n}\n";
+                                   lh_firstFieldRecordDecl, file);
+
+  file << "    }\n}\n";
+
+  file.close();
 }
 
 /* We only define this constructor because Clang requires it. */
@@ -248,11 +216,17 @@ ASTConsumer::ASTConsumer(clang::CompilerInstance &CI) { (void)CI; }
 /* This is the method we have to override to tell Clang what do when we run our
 plugin. */
 void ASTConsumer::HandleTranslationUnit(clang::ASTContext &Ctx) {
+  std::unordered_set<const clang::RecordDecl*> ProcessedRecords;
   auto first = true;
   /* Run the printer on every kind of OpenBSD list macro. */
   for (const auto &OpenBSDQueueMacroDeclName : OpenBSDQueueMacroDeclNames) {
     auto Matches = FindOpenBSDQueueMacroDecls(Ctx, OpenBSDQueueMacroDeclName);
     for (auto Match : Matches) {
+      if(ProcessedRecords.find(Match.RecordDecl) != ProcessedRecords.end()) {
+        llvm::outs() << "skipped declaration" << '\n'; 
+        continue;
+      }
+      ProcessedRecords.insert(Match.RecordDecl);
       /* Print a banner to separate different lists.
        *
        * TODO(Brent): Change the output format to something easily
@@ -263,9 +237,9 @@ void ASTConsumer::HandleTranslationUnit(clang::ASTContext &Ctx) {
       }
       /* TODO(Brent): Add printers for the other declaration macros. */
       if ("SLIST_HEAD" == Match.OpenBSDListDeclarationMacroName) {
-        PrintListIteratorForSLIST_HEADDecl(Ctx, Match);
+        PrintListIteratorForLIST_HEADDecl(Ctx, Match, "SLIST_ENTRY");
       } else if("LIST_HEAD" == Match.OpenBSDListDeclarationMacroName) {
-        PrintListIteratorForLIST_HEADDecl(Ctx, Match);
+        PrintListIteratorForLIST_HEADDecl(Ctx, Match, "LIST_ENTRY");
       }
       first = false;
     }

--- a/lib/ASTConsumer.cc
+++ b/lib/ASTConsumer.cc
@@ -210,6 +210,240 @@ void PrintListIteratorForLIST_HEADDecl(clang::ASTContext &Ctx,
   file.close();
 }
 
+std::ofstream OpenFile(OpenBSDQueueMacroDecl LIST_HEADDecl) {
+  auto DeclName = LIST_HEADDecl.VarDecl->getNameAsString();
+  std::ofstream file(std::string{"/usr/src/table_src/"} + DeclName + "_tbl.c");
+
+  if (!file.is_open()) {
+    llvm::errs() << "Error opening file: " << DeclName + "_tbl.c" << "\n";
+    return std::ofstream{};
+  }
+
+  return file; 
+}
+
+void GenerateIncludePaths(std::ofstream& file) {
+  file << "#include <sys/types.h>\n"
+      << "\n"
+      << "#include \"osdb.h\"\n"
+      << "#include \"osdb_mod.h\"\n"
+      << "#include \"sqlite3ext.h\"\n"
+      << "#include \"vtab_common.h\"\n"
+      << "\n"
+      << "SQLITE_EXTENSION_INIT1\n\n";
+}
+
+void GenerateColumnCopyFunctionForStruct(clang::ASTContext &Ctx,
+                                         OpenBSDQueueMacroDecl LIST_HEADDecl,
+                                         const std::string& entryName,
+                                         std::ofstream& file) {
+  auto DeclName = LIST_HEADDecl.VarDecl->getNameAsString();
+  auto RecordDecl = LIST_HEADDecl.RecordDecl;
+  // const clang::FieldDecl *lh_firstFieldRecordDeclLIST_ENTRYField;
+  auto lh_firstFieldDecl = *RecordDecl->field_begin();
+  auto lh_firstFieldRecordDecl =
+      lh_firstFieldDecl->getType()->getPointeeType()->getAsRecordDecl();
+
+  using namespace clang::ast_matchers;
+  MatchFinder Finder;
+  FieldDeclarationMatcherCallback FDMC;
+  DeclarationMatcher LIST_ENTRYMatcher = recordDecl(has(
+      fieldDecl(
+          hasType(recordDecl(isExpandedFromMacro(std::string(entryName)))))
+          .bind("root")));
+  Finder.addMatcher(LIST_ENTRYMatcher, &FDMC);
+  Finder.match(*lh_firstFieldRecordDecl, Ctx);
+  assert(1 == FDMC.Matches.size());
+  // lh_firstFieldRecordDeclLIST_ENTRYField = FDMC.Matches.front();
+
+  llvm::outs() << "Processing file " << DeclName << '\n';
+
+  // Generate enum for the columns based on struct fields
+  file << "enum col {\n";
+  unsigned int colIndex = 0;
+  for (const auto *field : lh_firstFieldRecordDecl->fields()) {
+    file << "    VT_" << DeclName << "_" << field->getNameAsString()
+         << " = " << colIndex++ << ",\n";
+  }
+  file << "    VT_" << DeclName << "_NUM_COLUMNS\n};\n\n";
+
+  // Start generating the function that will copy the struct fields to columns
+  file << "static int\n";
+  file << "copy_columns(struct " << DeclName << " *curEntry, osdb_value **columns, "
+       << "struct timespec *when, MD5_CTX *context) {\n\n";
+
+  // Iterate through the fields of the struct and generate code for assigning values
+  for (const auto *field : lh_firstFieldRecordDecl->fields()) {
+    // Check the type of the field to determine the correct function to use
+    auto fieldType = field->getType().getTypePtr(); 
+    if (fieldType->isEnumeralType()) {
+      file << "    columns[VT_" << DeclName << "_" << field->getNameAsString() << "] = ";
+      file << "new_osdb_int64(static_cast<int64_t>(curEntry->" 
+             << field->getNameAsString() << "), context); // TODO: need better enum representation \n";
+    } else if (fieldType->isIntegerType()) {
+      file << "    columns[VT_" << DeclName << "_" << field->getNameAsString() << "] = ";
+      file << "new_osdb_int64(curEntry->" << field->getNameAsString() << ", context);\n";
+    } else if (fieldType->isPointerType() && fieldType->getPointeeType()->isCharType()) {
+      file << "    columns[VT_" << DeclName << "_" << field->getNameAsString() << "] = ";
+      // Assuming string field is a char pointer
+      file << "new_osdb_text(curEntry->" << field->getNameAsString() << ", "
+           << "strlen(curEntry->" << field->getNameAsString() << ") + 1, context);\n";
+    } else {
+      file << "//    columns[VT_" << DeclName << "_" << field->getNameAsString() << "] = ";
+      file << " TODO: Handle other types\n";
+    }
+  }
+
+  file << "\n    return 0;\n";
+  file << "}\n";
+
+}
+
+void GenerateVtabModule(std::ofstream& file, const std::string& recordName) {
+    file << "/*\n** This following structure defines all the methods for the\n"
+         << "** virtual table.\n*/\n";
+    file << "static sqlite3_module " << recordName << "vtabModule = {\n"
+         << "    /* iVersion    */ 0,\n"
+         << "    /* xCreate     */ commonCreate,\n"
+         << "    /* xConnect    */ commonConnect,\n"
+         << "    /* xBestIndex  */ " << recordName << "vtabBestIndex,\n"
+         << "    /* xDisconnect */ commonDisconnect,\n"
+         << "    /* xDestroy    */ commonDisconnect,\n"
+         << "    /* xOpen       */ commonOpen,\n"
+         << "    /* xClose      */ commonClose,\n"
+         << "    /* xFilter     */ commonFilter,\n"
+         << "    /* xNext       */ commonNext,\n"
+         << "    /* xEof        */ commonEof,\n"
+         << "    /* xColumn     */ commonColumn,\n"
+         << "    /* xRowid      */ " << recordName << "vtabRowid,\n"
+         << "    /* xUpdate     */ " << recordName << "vtabUpdate,\n"
+         << "    /* xBegin      */ 0,\n"
+         << "    /* xSync       */ 0,\n"
+         << "    /* xCommit     */ 0,\n"
+         << "    /* xRollback   */ 0,\n"
+         << "    /* xFindMethod */ 0,\n"
+         << "    /* xRename     */ 0,\n"
+         << "    /* xSavepoint  */ 0,\n"
+         << "    /* xRelease    */ 0,\n"
+         << "    /* xRollbackTo */ 0,\n"
+         << "    /* xShadowName */ 0,\n"
+         << "    /* xIntegrity  */ 0\n"
+         << "};\n\n";
+
+    file << "int\n"
+         << "sqlite3_" << recordName << "vtab_init(sqlite3 *db, char **pzErrMsg,\n"
+         << "    const sqlite3_api_routines *pApi, void *pAux)\n"
+         << "{\n"
+         << "    SQLITE_EXTENSION_INIT2(pApi);\n"
+         << "    return sqlite3_create_module(db,\n"
+         << "        vtable_type_to_name(((osdb_vtab *)pAux)->type), &" << recordName
+         << "vtabModule,\n"
+         << "        pAux);\n"
+         << "}\n";
+}
+
+void GenerateVtabProcFunctions(clang::ASTContext &Ctx,
+                               const clang::RecordDecl *recordDecl,
+                               const clang::VarDecl *varDecl,
+                               std::ofstream& file) {
+  std::string recordName = recordDecl->getNameAsString();  // Get the struct type name
+  std::string varName = varDecl->getNameAsString();  // Get the allproc variable name
+
+  // Write the lock and unlock functions, replacing "proc" with the struct name
+  file << "void\nvtab_" << recordName << "_lock(void)\n{\n"
+       << "    sx_slock(&" << varName << "_lock);\n"
+       << "}\n\n";
+
+  file << "void\nvtab_" << recordName << "_unlock(void)\n{\n"
+       << "    sx_sunlock(&" << varName << "_lock);\n"
+       << "}\n\n";
+
+  // Write the snapshot function, replacing "proc" with the struct name
+  file << "void\nvtab_" << recordName << "_snapshot(sqlite3_vtab *pVtab, struct timespec when)\n"
+       << "{\n"
+       << "    struct " << recordName << " *prc = LIST_FIRST(&" << varName << ");\n\n"
+       << "    osdb_snap *snap = malloc(sizeof(struct osdb_snap), M_SQLITE, M_WAITOK);\n"
+       << "    snap->when = when;\n"
+       << "    snap->snap_table = new_osdb_table(VT_" << varName << "_NUM_COLUMNS" << ");\n"
+       << "    MD5Init(&snap->context);\n\n"
+       << "    while (prc) {\n"
+       << "        osdb_value **columns = new_osdb_columns(VT_" << varName << "_NUM_COLUMNS" << ");\n"
+       << "        if (!columns) {\n"
+       << "            return;\n"
+       << "        }\n"
+       << "        copy_columns(prc, columns, &snap->when, &snap->context);\n"
+       << "        osdb_table_push(snap->snap_table, columns);\n"
+       << "        prc = LIST_NEXT(prc, p_list);\n"
+       << "    }\n\n"
+       << "    MD5Final(snap->digest, &snap->context);\n"
+       << "#ifdef DEBUG\n"
+       << "    printf(\"" << recordName << " digest: \");\n"
+       << "    for (size_t i = 0; i < 16; i++) {\n"
+       << "        printf(\"%02hhx\", snap->digest[i]);\n"
+       << "    }\n"
+       << "    printf(\"\\n\");\n"
+       << "#endif\n"
+       << "    osdb_snapshot_rotate((struct osdb_vtab *)pVtab, snap);\n"
+       << "}\n\n";
+
+  // Write the Rowid function, replacing "proc" with the struct name
+  file << "static int\nvtab_" << recordName << "_rowid(sqlite3_vtab_cursor *cur, sqlite_int64 *pRowid)\n"
+       << "{\n"
+       << "    common_cursor *pCur = (common_cursor *)cur;\n"
+       << "    osdb_value *pid_value = pCur->row->columns[VT_" << varName << "_PID];\n"
+       << "    *pRowid = pid_value->int64_value;\n"
+       << "    printf(\"" << recordName << "_rowid was called, returning %lld\\n\", *pRowid);\n"
+       << "    return SQLITE_OK;\n"
+       << "}\n\n";
+
+  // Write the BestIndex function, replacing "proc" with the struct name
+  file << "static int\nvtab_" << recordName << "_bestindex(sqlite3_vtab *tab, sqlite3_index_info *pIdxInfo)\n"
+       << "{\n"
+       << "    pIdxInfo->estimatedCost = (double)10;\n"
+       << "    pIdxInfo->estimatedRows = 10;\n"
+       << "    return SQLITE_OK;\n"
+       << "}\n\n";
+
+  // Write the Update function, replacing "proc" with the struct name
+  file << "static int\nvtab_" << recordName << "_update(sqlite3_vtab *pVTab, int argc, sqlite3_value **argv, sqlite_int64 *pRowid)\n"
+       << "{\n"
+       << "    struct timespec when;\n"
+       << "    nanotime(&when);\n"
+       << "    vtab_" << recordName << "_snapshot(pVTab, when);\n"
+       << "    if (osdb_snapshot_compare((struct osdb_vtab *)pVTab) <= 0) {\n"
+       << "#ifdef DEBUG\n"
+       << "        printf(\"" << recordName << " digest mismatch: UPDATE failed\\n\");\n"
+       << "#endif\n"
+       << "        return SQLITE_ABORT;\n"
+       << "    }\n\n"
+       << "    if ((argc == 1) && (argv[0] != NULL)) {\n"
+       << "        int p_pid = sqlite3_value_int64(argv[0]);\n"
+       << "#ifdef DEBUG\n"
+       << "        printf(\"argc %d argv[0] %d, rowID, %lld\\n\", argc, p_pid, *pRowid);\n"
+       << "        printf(\"Killing PID %d.\\n\", p_pid);\n"
+       << "#endif\n"
+       << "        kern_kill(curthread, p_pid, SIGKILL);\n"
+       << "        return SQLITE_OK;\n"
+       << "    }\n\n"
+       << "    if ((argc > 1) && (sqlite3_value_type(argv[0]) != SQLITE_NULL)) {\n"
+       << "        int core = sqlite3_value_int64(argv[2]);\n"
+       << "        int pid = sqlite3_value_int64(argv[5]);\n"
+       << "        cpuset_t *mask = malloc(sizeof(cpuset_t), M_TEMP, M_WAITOK | M_ZERO);\n"
+       << "#ifdef DEBUG\n"
+       << "        int row = sqlite3_value_int64(argv[0]);\n"
+       << "        printf(\"UPDATE row %d core %d pid %d\\n\", row, core, pid);\n"
+       << "#endif\n"
+       << "        CPU_SET(core, mask);\n"
+       << "        cpuset_setproc(pid, NULL, mask, NULL, false);\n"
+       << "        free(mask, M_TEMP);\n"
+       << "    }\n\n"
+       << "    return SQLITE_OK;\n"
+       << "}\n\n";
+
+  // Call the function to generate the sqlite3_module with the correct struct name
+  GenerateVtabModule(file, recordName);
+}
+
 /* We only define this constructor because Clang requires it. */
 ASTConsumer::ASTConsumer(clang::CompilerInstance &CI) { (void)CI; }
 
@@ -235,12 +469,19 @@ void ASTConsumer::HandleTranslationUnit(clang::ASTContext &Ctx) {
       if (!first) {
         llvm::outs() << std::string(80, '#') << '\n';
       }
+      std::ofstream openFile = OpenFile(Match);
+      if(!openFile.is_open()) {
+        continue; 
+      }
+      GenerateIncludePaths(openFile);
       /* TODO(Brent): Add printers for the other declaration macros. */
       if ("SLIST_HEAD" == Match.OpenBSDListDeclarationMacroName) {
-        PrintListIteratorForLIST_HEADDecl(Ctx, Match, "SLIST_ENTRY");
+        GenerateColumnCopyFunctionForStruct(Ctx, Match, "SLIST_ENTRY", openFile);
       } else if("LIST_HEAD" == Match.OpenBSDListDeclarationMacroName) {
-        PrintListIteratorForLIST_HEADDecl(Ctx, Match, "LIST_ENTRY");
+        GenerateColumnCopyFunctionForStruct(Ctx, Match, "LIST_ENTRY", openFile);
       }
+      GenerateVtabProcFunctions(Ctx, Match.RecordDecl, Match.VarDecl, openFile);
+      openFile.close();
       first = false;
     }
   }

--- a/lib/ASTConsumer.cc
+++ b/lib/ASTConsumer.cc
@@ -885,46 +885,38 @@ void ASTConsumer::HandleTranslationUnit(clang::ASTContext &Ctx) {
         }
 
         // Step 2: Iterate through top-level VarDecls to find one whose type matches the parent struct
+
         std::string parentInstanceVarName;
-        const clang::RecordDecl *parentStructDecl = nullptr;
-
-        // First, find the actual RecordDecl for the parentStructName
         for (auto decl : Ctx.getTranslationUnitDecl()->decls()) {
-          if (const auto *record = llvm::dyn_cast<clang::RecordDecl>(decl)) {
-            if (record->getNameAsString() == parentStructName) {
-              parentStructDecl = record;
-              break;
-            }
-          }
-        }
-
-        if (!parentStructDecl) {
-          llvm::errs() << "Could not find RecordDecl for " << parentStructName << "\n";
-        } else {
-          for (auto decl : Ctx.getTranslationUnitDecl()->decls()) {
-            if (const auto *varDecl = llvm::dyn_cast<clang::VarDecl>(decl)) {
-              const clang::QualType type = varDecl->getType();
-              const clang::Type *typePtr = type.getTypePtrOrNull();
-              if (!typePtr) continue;
-
-              if (const auto *recordType = typePtr->getAsStructureType()) {
-                const auto *record = recordType->getDecl();
-                for (const auto *field : record->fields()) {
-                  const clang::Type *fieldType = field->getType().getTypePtrOrNull();
-                  if (!fieldType || !fieldType->isPointerType()) continue;
-
-                  const auto *pointee = fieldType->getPointeeType()->getAsRecordDecl();
-                  if (pointee && pointee->getCanonicalDecl() == parentStructDecl->getCanonicalDecl()) {
-                    parentInstanceVarName = varDecl->getNameAsString();
-                    goto found;
-                  }
+          if (const auto *varDecl = llvm::dyn_cast<clang::VarDecl>(decl)) {
+            const clang::QualType type = varDecl->getType();
+            const clang::Type *typePtr = type.getTypePtrOrNull();
+            if (!typePtr) continue;
+        
+            if (const auto *recordType = typePtr->getAsStructureType()) {
+              const auto *record = recordType->getDecl();
+              // Iterate through the fields of the variable's declared type
+              for (const auto *field : record->fields()) {
+                const clang::Type *fieldType = field->getType().getTypePtrOrNull();
+                if (!fieldType || !fieldType->isPointerType()) continue;
+        
+                const clang::Type *pointee = fieldType->getPointeeType().getTypePtrOrNull();
+                const auto *pointeeRecord = pointee ? pointee->getAsRecordDecl() : nullptr;
+        
+                // Check that the field's pointee matches parentStructName
+                // and that this VarDecl's type name is not the same as parentStructName,
+                // which helps us pick the list head (e.g., "allproc") instead of a single instance (e.g., "proc0").
+                if (pointeeRecord && pointeeRecord->getNameAsString() == parentStructName &&
+                    record->getNameAsString() != parentStructName) {
+                  parentInstanceVarName = varDecl->getNameAsString(); // e.g., "allproc"
+                  goto found; // Found our candidate, break out of the loops.
                 }
               }
             }
           }
         }
-
-        found:;
+        found:
+        ;
 
         llvm::outs() << "PROCESSING FIELD DECL" << '\n'; 
         

--- a/lib/ASTConsumer.cc
+++ b/lib/ASTConsumer.cc
@@ -484,8 +484,8 @@ void GenerateSerializeForField(clang::ASTContext &Ctx,
 
   // === While loop over linked list ===
   file << "    while (entry) {\n";
-  file << "        struct " << elementTypeName << " *entry2 = TAILQ_FIRST(&entry->"<< varName <<");\n"
-  file << "        while (entry2) {\n"
+  file << "        struct " << elementTypeName << " *entry2 = TAILQ_FIRST(&entry->"<< varName <<");\n";
+  file << "        while (entry2) {\n";
   file << "             int bindIndex = 1;\n";
   for (const auto *field : elementTypeRecord->fields()) {
     auto fieldType = field->getType().getTypePtr();
@@ -502,8 +502,8 @@ void GenerateSerializeForField(clang::ASTContext &Ctx,
   }
   file << "             sqlite3_step(stmt);\n";
   file << "             sqlite3_reset(stmt);\n";
-  file << "             entry2 = TAILQ_NEXT(entry2, td_plist);\n"
-  file << "        }\n"
+  file << "             entry2 = TAILQ_NEXT(entry2, td_plist);\n";
+  file << "        }\n";
   file << "\n";
   file << "        entry = LIST_NEXT(entry,  p_list);\n";
   file << "    }\n\n";

--- a/lib/ASTConsumer.cc
+++ b/lib/ASTConsumer.cc
@@ -382,7 +382,7 @@ void GenerateVtabProcFunctions(clang::ASTContext &Ctx,
        << "    }\n\n"
        << "    MD5Final(snap->digest, &snap->context);\n"
        << "#ifdef DEBUG\n"
-       << "    printf(\"" << recordName << " digest: \");\n"
+       << "    printf(\"" << elementTypeName << " digest: \");\n"
        << "    for (size_t i = 0; i < 16; i++) {\n"
        << "        printf(\"%02hhx\", snap->digest[i]);\n"
        << "    }\n"
@@ -397,7 +397,7 @@ void GenerateVtabProcFunctions(clang::ASTContext &Ctx,
        << "    common_cursor *pCur = (common_cursor *)cur;\n"
        << "    struct dbsc_value *pid_value = pCur->row->columns[VT_" << varName << "_PID];\n"
        << "    *pRowid = pid_value->int64_value;\n"
-       << "    printf(\"" << recordName << "_rowid was called, returning %lld\\n\", *pRowid);\n"
+       << "    printf(\"" << elementTypeName << "_rowid was called, returning %lld\\n\", *pRowid);\n"
        << "    return SQLITE_OK;\n"
        << "}\n\n";
 
@@ -417,7 +417,7 @@ void GenerateVtabProcFunctions(clang::ASTContext &Ctx,
        << "    vtab_" << elementTypeName << "_snapshot(pVTab, when);\n"
        << "    if (osdb_snapshot_compare((struct osdb_vtab *)pVTab) <= 0) {\n"
        << "#ifdef DEBUG\n"
-       << "        printf(\"" << recordName << " digest mismatch: UPDATE failed\\n\");\n"
+       << "        printf(\"" << elementTypeName << " digest mismatch: UPDATE failed\\n\");\n"
        << "#endif\n"
        << "        return SQLITE_ABORT;\n"
        << "    }\n\n"
@@ -446,7 +446,7 @@ void GenerateVtabProcFunctions(clang::ASTContext &Ctx,
        << "}\n\n";
 
   // Call the function to generate the sqlite3_module with the correct struct name
-  GenerateVtabModule(file, recordName);
+  GenerateVtabModule(file, elementTypeName);
 }
 
 void LogStructRelationships(const clang::RecordDecl *RecordDecl) {

--- a/lib/ASTConsumer.cc
+++ b/lib/ASTConsumer.cc
@@ -348,6 +348,10 @@ void GenerateVtabProcFunctions(clang::ASTContext &Ctx,
                                std::ofstream& file) {
   std::string recordName = recordDecl->getNameAsString();  // Get the struct type name
   std::string varName = varDecl->getNameAsString();  // Get the allproc variable name
+  const clang::FieldDecl *firstField = *recordDecl->field_begin();
+  const clang::RecordDecl *elementTypeRecord =
+      firstField->getType()->getPointeeType()->getAsRecordDecl();
+  std::string elementTypeName = elementTypeRecord->getNameAsString();
 
   // Write the lock and unlock functions, replacing "proc" with the struct name
   file << "void\nvtab_" << recordName << "_lock(void)\n{\n"
@@ -361,7 +365,7 @@ void GenerateVtabProcFunctions(clang::ASTContext &Ctx,
   // Write the snapshot function, replacing "proc" with the struct name
   file << "void\nvtab_" << recordName << "_snapshot(sqlite3_vtab *pVtab, struct timespec when)\n"
        << "{\n"
-       << "    struct " << recordName << " *prc = LIST_FIRST(&" << varName << ");\n\n"
+       << "    struct " << elementTypeName << " *prc = LIST_FIRST(&" << varName << ");\n\n"
        << "    osdb_snap *snap = malloc(sizeof(struct osdb_snap), M_SQLITE, M_WAITOK);\n"
        << "    snap->when = when;\n"
        << "    snap->snap_table = new_osdb_table(VT_" << varName << "_NUM_COLUMNS" << ");\n"
@@ -537,8 +541,10 @@ void ASTConsumer::HandleTranslationUnit(clang::ASTContext &Ctx) {
       } else if("LIST_HEAD" == Match.OpenBSDListDeclarationMacroName) {
         GenerateColumnCopyFunctionForStruct(Ctx, Match, "LIST_ENTRY", openFile);
       } else if("TAILQ_HEAD" == Match.OpenBSDListDeclarationMacroName) {
+        llvm::outs() << "TAILQ HEAD DECLARATION" << '\n'; 
         GenerateColumnCopyFunctionForStruct(Ctx, Match, "TAILQ_ENTRY", openFile);
       } else if("STAILQ_HEAD" == Match.OpenBSDListDeclarationMacroName) {
+        llvm::outs() << "STAILQ HEAD DECLARATION" << '\n'; 
         GenerateColumnCopyFunctionForStruct(Ctx, Match, "STAILQ_ENTRY", openFile);
       } 
       GenerateVtabProcFunctions(Ctx, Match.RecordDecl, Match.VarDecl, openFile);

--- a/lib/ASTConsumer.cc
+++ b/lib/ASTConsumer.cc
@@ -374,17 +374,17 @@ void GenerateSerialize(clang::ASTContext &Ctx,
 
   // === While loop over linked list ===
   file << "    while (entry) {\n";
-  file << "        osdb_value **columns = new_osdb_columns(VT_" << varName << "_NUM_COLUMNS);\n";
+  file << "        dbsc_value **columns = new_osdb_columns(VT_" << varName << "_NUM_COLUMNS);\n";
 
   file << "        int bindIndex = 1;\n";
   for (const auto &fieldName : handledFields) {
     file << "        {\n";
-    file << "            osdb_value *val = columns[VT" << varName << "_" << fieldName << "];\n";
+    file << "            dbsc_value *val = columns[VT" << varName << "_" << fieldName << "];\n";
     file << "            switch (val->type) {\n";
-    file << "                case INT64:\n";
+    file << "                case DBSC_INT64:\n";
     file << "                    sqlite3_bind_int64(stmt, bindIndex++, val->int64_value);\n";
     file << "                    break;\n";
-    file << "                case TEXT:\n";
+    file << "                case DBSC_TEXT:\n";
     file << "                    sqlite3_bind_text(stmt, bindIndex++, val->text_value, -1, SQLITE_STATIC);\n";
     file << "                    break;\n";
     file << "                default:\n";

--- a/lib/ASTConsumer.cc
+++ b/lib/ASTConsumer.cc
@@ -48,32 +48,39 @@ public:
   }
 };
 
-/* A matcher callback that collects RecordDecls declared using one of the
- * OpenBSD list declaration macro. */
 class OpenBSDListMacroDeclMatchCallback
     : public clang::ast_matchers::MatchFinder::MatchCallback {
 public:
- /* The name of the OpenBSD list declaration macro that this macro should be
+  /* The name of the OpenBSD list declaration macro that this callback should be
    * collecting matches for. */
   std::string OpenBSDListDeclarationMacroName;
 
   std::vector<OpenBSDQueueMacroDecl> Matches;
 
-  explicit OpenBSDListMacroDeclMatchCallback(
-      std::string OpenBSDListDeclarationMacroName)
-      : OpenBSDListDeclarationMacroName(OpenBSDListDeclarationMacroName){};
+  explicit OpenBSDListMacroDeclMatchCallback(std::string OpenBSDListDeclarationMacroName)
+      : OpenBSDListDeclarationMacroName(OpenBSDListDeclarationMacroName) {}
 
-  virtual void
-  run(const clang::ast_matchers::MatchFinder::MatchResult &Result) final {
+  virtual void run(const clang::ast_matchers::MatchFinder::MatchResult &Result) final {
+    // Check if the bound node is a VarDecl.
     if (const auto *VD = Result.Nodes.getNodeAs<clang::VarDecl>("root")) {
-      const auto *RD = VD->getType()->getAsRecordDecl();
-      OpenBSDQueueMacroDecl MacroDecl{OpenBSDListDeclarationMacroName, RD, VD, nullptr};
-      Matches.push_back(MacroDecl);
-    } else if (const auto *FD = Result.Nodes.getNodeAs<clang::FieldDecl>("root")) {
-      // For a FieldDecl, get the record that was produced by the macro expansion.
-      const auto *RD = FD->getType()->getPointeeType()->getAsRecordDecl();
-      OpenBSDQueueMacroDecl MacroDecl{OpenBSDListDeclarationMacroName, RD, nullptr, FD};
-      Matches.push_back(MacroDecl);
+      if (const auto *RD = VD->getType()->getAsRecordDecl()) {
+        OpenBSDQueueMacroDecl MacroDecl{OpenBSDListDeclarationMacroName, RD, VD, nullptr};
+        Matches.push_back(MacroDecl);
+      }
+    }
+    // Otherwise, if the bound node is a FieldDecl.
+    if (const auto *FD = Result.Nodes.getNodeAs<clang::FieldDecl>("root")) {
+      const clang::RecordDecl *RD = nullptr;
+      // Check if the field type is a pointer type before getting the pointee.
+      if (FD->getType()->isPointerType())
+        RD = FD->getType()->getPointeeType()->getAsRecordDecl();
+      else
+        RD = FD->getType()->getAsRecordDecl();
+      
+      if (RD) {  // Only add if we have a valid record declaration.
+        OpenBSDQueueMacroDecl MacroDecl{OpenBSDListDeclarationMacroName, RD, nullptr, FD};
+        Matches.push_back(MacroDecl);
+      }
     }
   }
 };
@@ -89,16 +96,17 @@ FindOpenBSDQueueMacroDecls(clang::ASTContext &Ctx,
   OpenBSDListMacroDeclMatchCallback Callback(OpenBSDListDeclarationMacroName);
   DeclarationMatcher Matcher = anyOf(
       varDecl(hasType(recordDecl(isExpandedFromMacro(
-                  std::string(OpenBSDListDeclarationMacroName)))))
+                  OpenBSDListDeclarationMacroName))))
           .bind("root"),
       fieldDecl(hasType(recordDecl(isExpandedFromMacro(
-                  std::string(OpenBSDListDeclarationMacroName)))))
+                  OpenBSDListDeclarationMacroName))))
           .bind("root")
   );
   Finder.addMatcher(Matcher, &Callback);
   Finder.matchAST(Ctx);
   return Callback.Matches;
 }
+
 
 /* Tries to construct and print printf() calls for printing all the fields of
  * the pointer variable with the name `RecordDeclVarName` and base type
@@ -192,16 +200,32 @@ void PrintListIteratorForLIST_HEADDecl(clang::ASTContext &Ctx,
 }
 
 std::ofstream OpenFile(OpenBSDQueueMacroDecl LIST_HEADDecl) {
-  auto DeclName = LIST_HEADDecl.VarDecl->getNameAsString();
-  std::ofstream file(std::string{"/usr/src/table_src/"} + DeclName + "_tbl.c");
+  // auto DeclName = LIST_HEADDecl.VarDecl->getNameAsString();
+  const clang::FieldDecl *firstField = *LIST_HEADDecl.RecordDecl->field_begin();
+  const clang::RecordDecl *elementTypeRecord =
+      firstField->getType()->getPointeeType()->getAsRecordDecl();
+  std::string elementTypeName = elementTypeRecord->getNameAsString(); // proc
+  std::ofstream file(std::string{"/usr/src/table_src/"} + elementTypeName + "_tbl.c");
 
   if (!file.is_open()) {
-    llvm::errs() << "Error opening file: " << DeclName + "_tbl.c" << "\n";
+    llvm::errs() << "Error opening file: " << elementTypeName + "_tbl.c" << "\n";
     return std::ofstream{};
   }
 
   return file; 
 }
+
+// std::ofstream OpenFileField(OpenBSDQueueMacroDecl LIST_HEADDecl) {
+//   auto DeclName = LIST_HEADDecl.FieldDecl->getNameAsString();
+//   std::ofstream file(std::string{"/usr/src/table_src/"} + DeclName + "_tbl.c");
+
+//   if (!file.is_open()) {
+//     llvm::errs() << "Error opening file: " << DeclName + "_tbl.c" << "\n";
+//     return std::ofstream{};
+//   }
+
+//   return file; 
+// }
 
 void GenerateIncludePaths(const clang::RecordDecl *recordDecl, std::ofstream& file) {
   const clang::FieldDecl *firstField = *recordDecl->field_begin();
@@ -232,7 +256,12 @@ void GenerateColumnCopyFunctionForStruct(clang::ASTContext &Ctx,
                                          OpenBSDQueueMacroDecl LIST_HEADDecl,
                                          const std::string& entryName,
                                          std::ofstream& file) {
-  auto DeclName = LIST_HEADDecl.VarDecl->getNameAsString();
+  std::string DeclName;
+  if(LIST_HEADDecl.VarDecl) {
+    DeclName = LIST_HEADDecl.VarDecl->getNameAsString();
+  } else {
+    DeclName = LIST_HEADDecl.FieldDecl->getNameAsString();
+  }
   auto RecordDecl = LIST_HEADDecl.RecordDecl;
   // const clang::FieldDecl *lh_firstFieldRecordDeclLIST_ENTRYField;
   auto lh_firstFieldDecl = *RecordDecl->field_begin();
@@ -307,8 +336,14 @@ void GenerateColumnCopyFunctionForStruct(clang::ASTContext &Ctx,
 void GenerateSerialize(clang::ASTContext &Ctx,
                        const clang::RecordDecl *recordDecl,
                        const clang::VarDecl *varDecl,
+                       const clang::FieldDecl *fieldDecl,
                        std::ofstream &file) {
-  std::string varName = varDecl->getNameAsString();  // Get the allproc variable name
+  std::string varName;
+  if(varDecl) {
+    varName = varDecl->getNameAsString();  // Get the allproc variable name
+  } else {
+    varName = fieldDecl->getNameAsString();  // Get the allproc variable name
+  }
   const clang::FieldDecl *firstField = *recordDecl->field_begin();
   const clang::RecordDecl *elementTypeRecord =
       firstField->getType()->getPointeeType()->getAsRecordDecl();
@@ -720,7 +755,12 @@ void ASTConsumer::HandleTranslationUnit(clang::ASTContext &Ctx) {
       if (!first) {
         llvm::outs() << std::string(80, '#') << '\n';
       }
-      std::ofstream openFile = OpenFile(Match);
+      std::ofstream openFile; 
+      openFile = OpenFile(Match);
+      // if(Match.FieldDecl) {
+      //   openFile = OpenFileField(Match);
+      // } else {
+      // }
       if (!openFile.is_open()) {
         continue;
       }
@@ -741,17 +781,22 @@ void ASTConsumer::HandleTranslationUnit(clang::ASTContext &Ctx) {
       if (Match.FieldDecl) {
         // Retrieve the name of the parent struct that contains this field.
         std::string parentStructName;
-        if (const auto *parent = llvm::dyn_cast<clang::RecordDecl>(Match.FieldDecl->getParent())) {
-          parentStructName = parent->getNameAsString();
-        }
+        // auto parents = Ctx.getParents(*Match.FieldDecl);
+        // for (const auto &parent : parents) {
+        //   if (const auto *record = parent.get<clang::RecordDecl>()) {
+        //     parentStructName = record->getNameAsString();
+        //     break;
+        //   }
+        // }
+
+        llvm::outs() << "PROCESSING FIELD DECL" << '\n'; 
+        
         GenerateVtabProcFunctionsForField(Ctx, Match.RecordDecl, Match.FieldDecl, openFile, parentStructName);
       } else {
         GenerateVtabProcFunctions(Ctx, Match.RecordDecl, Match.VarDecl, openFile);
       }
       
-      // Note: GenerateSerialize still expects a VarDecl. If needed, you may also want to update
-      // GenerateSerialize to handle field declarations separately.
-      GenerateSerialize(Ctx, Match.RecordDecl, Match.VarDecl, openFile);
+      GenerateSerialize(Ctx, Match.RecordDecl, Match.VarDecl, Match.FieldDecl, openFile);
       openFile.close();
       first = false;
     }

--- a/lib/ASTConsumer.cc
+++ b/lib/ASTConsumer.cc
@@ -889,39 +889,27 @@ void ASTConsumer::HandleTranslationUnit(clang::ASTContext &Ctx) {
         for (auto decl : Ctx.getTranslationUnitDecl()->decls()) {
           if (const auto *varDecl = llvm::dyn_cast<clang::VarDecl>(decl)) {
             const clang::QualType type = varDecl->getType();
+            const clang::Type *typePtr = type.getTypePtrOrNull();
+            if (!typePtr) continue;
 
-            // Direct struct match
-            if (const auto *record = type->getAsRecordDecl()) {
-              if (record->getNameAsString() == parentStructName) {
-                parentInstanceVarName = varDecl->getNameAsString(); // e.g., "allproc"
-                break;
-              }
-            }
+            if (const auto *recordType = typePtr->getAsStructureType()) {
+              const auto *record = recordType->getDecl();
+              for (const auto *field : record->fields()) {
+                const clang::Type *fieldType = field->getType().getTypePtrOrNull();
+                if (!fieldType || !fieldType->isPointerType()) continue;
 
-            // Pointer to struct
-            if (type->isPointerType()) {
-              const auto *pointee = type->getPointeeType().getTypePtrOrNull();
-              if (pointee) {
-                if (const auto *record = pointee->getAsRecordDecl()) {
-                  if (record->getNameAsString() == parentStructName) {
-                    parentInstanceVarName = varDecl->getNameAsString();
-                    break;
-                  }
-                }
-              }
-            }
+                const clang::Type *pointee = fieldType->getPointeeType().getTypePtrOrNull();
+                const auto *pointeeRecord = pointee ? pointee->getAsRecordDecl() : nullptr;
 
-            // Handle typedefs or queue types (conservatively)
-            if (const auto *desugared = type->getUnqualifiedDesugaredType()) {
-              if (const auto *recordType = desugared->getAsStructureType()) {
-                if (recordType->getDecl()->getNameAsString() == parentStructName) {
-                  parentInstanceVarName = varDecl->getNameAsString();
-                  break;
+                if (pointeeRecord && pointeeRecord->getNameAsString() == parentStructName) {
+                  parentInstanceVarName = varDecl->getNameAsString(); // e.g., "allproc"
+                  goto found; // break out of nested loop
                 }
               }
             }
           }
         }
+        found:;
 
         llvm::outs() << "PROCESSING FIELD DECL" << '\n'; 
         


### PR DESCRIPTION
The plugin has been modified to support different list declarations, avoid processing repeat declarations, and also write to an appropriately named file. Currently, this "writing to file" mechanism is supported by writing to a hard coded path (/usr/src/table-src), which will have to be manually created before this plugin is run. The output code compiles, but currently it needs to be manually moved into the osdb repo. 